### PR TITLE
Add more debugging to PyPI publishing workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -23,4 +23,7 @@ jobs:
         TWINE_USERNAME: __token__
       run: |
         python -m build
-        twine upload dist/*
+        echo "Built package successfully"
+        ls -la dist/
+        echo "Uploading to PyPI with verbose output"
+        twine upload --verbose dist/*


### PR DESCRIPTION
This PR adds more debugging information to the PyPI publishing workflow to help diagnose the issue with the PyPI token.