### PR TITLE
Fix: Use correct endpoint for cookie validation

### DIFF
--- a/fogis_api_client/fogis_api_client.py
+++ b/fogis_api_client/fogis_api_client.py
@@ -1059,8 +1059,8 @@ class FogisApiClient:
             return False
 
         try:
-            # Use the dashboard page which is likely to be lightweight
-            dashboard_url = f"{FogisApiClient.BASE_URL}/Default.aspx"
+            # Use the dashboard page which is the same one we're redirected to after login
+            dashboard_url = f"{FogisApiClient.BASE_URL}/"
 
             # Set up headers for the request
             headers = {

--- a/tests/test_cookie_auth.py
+++ b/tests/test_cookie_auth.py
@@ -102,7 +102,7 @@ class TestCookieAuth(unittest.TestCase):
         # Create a mock response for a successful validation
         mock_response = MagicMock()
         mock_response.text = "<html>Welcome to Fogis</html>"
-        mock_response.url = "https://fogis.svenskfotboll.se/mdk/Default.aspx"
+        mock_response.url = "https://fogis.svenskfotboll.se/mdk/"
         mock_response.raise_for_status = lambda: None
         mock_get.return_value = mock_response
 


### PR DESCRIPTION
## Description

This PR fixes the issue identified in #127 where the  method was using an incorrect endpoint for cookie validation.

## Changes

- Updated the endpoint URL in  from  to 
- Updated the corresponding test to use the correct URL

## Testing

All tests pass with the updated endpoint.

## Related Issues

Closes #127