### PR TITLE
Hotfix: Use correct endpoint for cookie validation (v0.3.1)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.1] - 2025-04-25
+
+### Fixed
+- Fixed incorrect endpoint used for cookie validation (Issue #127)
+
 ## [0.3.0] - 2025-04-25
 
 ### Added

--- a/fogis_api_client/fogis_api_client.py
+++ b/fogis_api_client/fogis_api_client.py
@@ -1059,8 +1059,8 @@ class FogisApiClient:
             return False
 
         try:
-            # Use the dashboard page which is likely to be lightweight
-            dashboard_url = f"{FogisApiClient.BASE_URL}/Default.aspx"
+            # Use the dashboard page which is the same one we're redirected to after login
+            dashboard_url = f"{FogisApiClient.BASE_URL}/"
 
             # Set up headers for the request
             headers = {

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="fogis-api-client-timmyBird",
-    version="0.3.0",
+    version="0.3.1",
     author="Bartek Svaberg",
     author_email="bartek.svaberg@gmail.com",
     description="A Python client for the FOGIS API (Svensk Fotboll)",

--- a/tests/test_cookie_auth.py
+++ b/tests/test_cookie_auth.py
@@ -102,7 +102,7 @@ class TestCookieAuth(unittest.TestCase):
         # Create a mock response for a successful validation
         mock_response = MagicMock()
         mock_response.text = "<html>Welcome to Fogis</html>"
-        mock_response.url = "https://fogis.svenskfotboll.se/mdk/Default.aspx"
+        mock_response.url = "https://fogis.svenskfotboll.se/mdk/"
         mock_response.raise_for_status = lambda: None
         mock_get.return_value = mock_response
 


### PR DESCRIPTION
## Description

This PR is a hotfix for the issue identified in #127 where the  method was using an incorrect endpoint for cookie validation.

## Changes

- Updated the endpoint URL in  from  to 
- Updated the corresponding test to use the correct URL
- Updated version to 0.3.1
- Updated changelog

## Testing

All tests pass with the updated endpoint.

## Related Issues

Closes #127