### PR TITLE
Add save_match_participant method to update player information

### DIFF
--- a/docs/api_endpoints.md
+++ b/docs/api_endpoints.md
@@ -35,6 +35,7 @@ https://fogis.svenskfotboll.se/mdk
 |----------|--------|-------------|------------|
 | `/MatchWebMetoder.aspx/GetMatchdeltagareListaForMatchlag` | POST | Fetches the list of players for a team | `matchlagid`: Integer |
 | `/MatchWebMetoder.aspx/GetMatchlagledareListaForMatchlag` | POST | Fetches the list of officials for a team | `matchlagid`: Integer |
+| `/MatchWebMetoder.aspx/SparaMatchdeltagare` | POST | Updates specific fields for a match participant | Participant data object with fields to update |
 
 ## Event Endpoints
 
@@ -73,6 +74,26 @@ https://fogis.svenskfotboll.se/mdk
   }
 }
 ```
+
+### Match Participant Update Data
+
+```json
+{
+  "matchdeltagareid": 46123762,  // ID of the match participant (match-specific, NOT the permanent spelareid)
+  "trojnummer": 92,            // Jersey number to update
+  "lagdelid": 0,               // Team part ID (typically 0)
+  "lagkapten": false,          // Boolean indicating if the player is team captain
+  "ersattare": false,          // Boolean indicating if the player is a substitute
+  "positionsnummerhv": 0,      // Position number (typically 0)
+  "arSpelandeLedare": false,   // Boolean indicating if the player is a playing leader
+  "ansvarig": false            // Boolean indicating if the player is responsible
+}
+```
+
+**Important Notes:**
+- The `matchdeltagareid` is a match-specific ID for a player, different from the permanent `spelareid`. When updating player information for a specific match, you must use the `matchdeltagareid`.
+- This endpoint updates only the fields you provide while preserving other player information. You must include the `matchdeltagareid` to identify which player to update, and then include only the fields you want to change.
+- All fields shown above are required by the API, but you can keep their current values if you don't want to change them.
 
 ## Common Issues and Solutions
 

--- a/fogis_api_client/fogis_api_client.py
+++ b/fogis_api_client/fogis_api_client.py
@@ -12,6 +12,7 @@ from fogis_api_client.types import (
     CookieDict,
     EventDict,
     MatchDict,
+    MatchParticipantDict,
     MatchResultDict,
     OfficialActionDict,
     OfficialDict,
@@ -92,9 +93,7 @@ class FogisApiClient:
         cookies (Optional[CookieDict]): Session cookies for authentication
     """
 
-    BASE_URL: str = (
-        "https://fogis.svenskfotboll.se/mdk"  # Define base URL as a class constant
-    )
+    BASE_URL: str = "https://fogis.svenskfotboll.se/mdk"  # Define base URL as a class constant
     logger: logging.Logger = logging.getLogger("fogis_api_client.api")
 
     def __init__(
@@ -227,9 +226,7 @@ class FogisApiClient:
             eventvalidation = soup.find("input", {"name": "__EVENTVALIDATION"})
 
             if not form and not (viewstate and eventvalidation):
-                error_msg = (
-                    "Login failed: Could not find login form or required form elements"
-                )
+                error_msg = "Login failed: Could not find login form or required form elements"
                 self.logger.error(error_msg)
                 raise FogisLoginError(error_msg)
 
@@ -265,15 +262,10 @@ class FogisApiClient:
 
             # Submit login form
             self.logger.debug("Attempting login")
-            response = self.session.post(
-                login_url, data=login_data, headers=headers, allow_redirects=False
-            )
+            response = self.session.post(login_url, data=login_data, headers=headers, allow_redirects=False)
 
             # Handle the redirect manually for better control
-            if (
-                response.status_code == 302
-                and "FogisMobilDomarKlient.ASPXAUTH" in response.cookies
-            ):
+            if response.status_code == 302 and "FogisMobilDomarKlient.ASPXAUTH" in response.cookies:
                 redirect_url = response.headers["Location"]
 
                 # Fix the redirect URL - the issue is here
@@ -298,10 +290,7 @@ class FogisApiClient:
                 self.logger.info("Login successful")
                 return self.cookies
             else:
-                error_msg = (
-                    f"Login failed: Invalid credentials or session issue. "
-                    f"Status code: {response.status_code}"
-                )
+                error_msg = f"Login failed: Invalid credentials or session issue. " f"Status code: {response.status_code}"
                 self.logger.error(error_msg)
                 raise FogisLoginError(error_msg)
 
@@ -310,9 +299,7 @@ class FogisApiClient:
             self.logger.error(error_msg)
             raise FogisAPIRequestError(error_msg)
 
-    def fetch_matches_list_json(
-        self, filter: Optional[Dict[str, Any]] = None
-    ) -> List[MatchDict]:
+    def fetch_matches_list_json(self, filter: Optional[Dict[str, Any]] = None) -> List[MatchDict]:
         """
         Fetches the list of matches for the logged-in referee.
 
@@ -353,12 +340,8 @@ class FogisApiClient:
 
         # Build the default payload with the same structure as v0.0.5
         today = datetime.today().strftime("%Y-%m-%d")
-        default_datum_fran = (datetime.today() - timedelta(days=7)).strftime(
-            "%Y-%m-%d"
-        )  # One week ago
-        default_datum_till = (datetime.today() + timedelta(days=365)).strftime(
-            "%Y-%m-%d"
-        )  # 365 days ahead
+        default_datum_fran = (datetime.today() - timedelta(days=7)).strftime("%Y-%m-%d")  # One week ago
+        default_datum_till = (datetime.today() + timedelta(days=365)).strftime("%Y-%m-%d")  # 365 days ahead
 
         payload_filter = {  # Build DEFAULT payload dictionary
             "datumFran": default_datum_fran,
@@ -416,16 +399,11 @@ class FogisApiClient:
         if isinstance(response_data, dict):
             return cast(MatchDict, response_data)
         else:
-            error_msg = (
-                f"Expected dictionary response but got "
-                f"{type(response_data).__name__}: {response_data}"
-            )
+            error_msg = f"Expected dictionary response but got " f"{type(response_data).__name__}: {response_data}"
             self.logger.error(error_msg)
             raise FogisDataError(error_msg)
 
-    def fetch_match_players_json(
-        self, match_id: Union[str, int]
-    ) -> Dict[str, List[PlayerDict]]:
+    def fetch_match_players_json(self, match_id: Union[str, int]) -> Dict[str, List[PlayerDict]]:
         """
         Fetches player information for a specific match.
 
@@ -460,16 +438,11 @@ class FogisApiClient:
             # Cast to the expected type
             return cast(Dict[str, List[PlayerDict]], response_data)
         else:
-            error_msg = (
-                f"Expected dictionary response but got "
-                f"{type(response_data).__name__}: {response_data}"
-            )
+            error_msg = f"Expected dictionary response but got " f"{type(response_data).__name__}: {response_data}"
             self.logger.error(error_msg)
             raise FogisDataError(error_msg)
 
-    def fetch_match_officials_json(
-        self, match_id: Union[str, int]
-    ) -> Dict[str, List[OfficialDict]]:
+    def fetch_match_officials_json(self, match_id: Union[str, int]) -> Dict[str, List[OfficialDict]]:
         """
         Fetches officials information for a specific match.
 
@@ -495,9 +468,7 @@ class FogisApiClient:
             ...     print("No referee assigned yet")
             Main referee: John Doe
         """
-        url = (
-            f"{FogisApiClient.BASE_URL}/MatchWebMetoder.aspx/GetMatchfunktionarerLista"
-        )
+        url = f"{FogisApiClient.BASE_URL}/MatchWebMetoder.aspx/GetMatchfunktionarerLista"
         match_id_int = int(match_id) if isinstance(match_id, (str, int)) else match_id
         payload = {"matchid": match_id_int}
 
@@ -507,10 +478,7 @@ class FogisApiClient:
             # Cast to the expected type
             return cast(Dict[str, List[OfficialDict]], response_data)
         else:
-            error_msg = (
-                f"Expected dictionary response but got "
-                f"{type(response_data).__name__}: {response_data}"
-            )
+            error_msg = f"Expected dictionary response but got " f"{type(response_data).__name__}: {response_data}"
             self.logger.error(error_msg)
             raise FogisDataError(error_msg)
 
@@ -547,10 +515,7 @@ class FogisApiClient:
             # Cast to the expected type
             return cast(List[EventDict], response_data)
         else:
-            error_msg = (
-                f"Expected list response but got "
-                f"{type(response_data).__name__}: {response_data}"
-            )
+            error_msg = f"Expected list response but got " f"{type(response_data).__name__}: {response_data}"
             self.logger.error(error_msg)
             raise FogisDataError(error_msg)
 
@@ -593,10 +558,7 @@ class FogisApiClient:
         elif isinstance(response_data, list):
             return cast(TeamPlayersResponse, {"spelare": response_data})
         else:
-            error_msg = (
-                f"Expected dictionary or list but got "
-                f"{type(response_data).__name__}: {response_data}"
-            )
+            error_msg = f"Expected dictionary or list but got " f"{type(response_data).__name__}: {response_data}"
             self.logger.error(error_msg)
             raise FogisDataError(error_msg)
 
@@ -635,10 +597,7 @@ class FogisApiClient:
         if isinstance(response_data, list):
             return cast(List[OfficialDict], response_data)
         else:
-            error_msg = (
-                f"Expected list response but got "
-                f"{type(response_data).__name__}: {response_data}"
-            )
+            error_msg = f"Expected list response but got " f"{type(response_data).__name__}: {response_data}"
             self.logger.error(error_msg)
             raise FogisDataError(error_msg)
 
@@ -722,16 +681,11 @@ class FogisApiClient:
         if isinstance(response_data, dict):
             return response_data
         else:
-            error_msg = (
-                f"Expected dictionary response but got "
-                f"{type(response_data).__name__}: {response_data}"
-            )
+            error_msg = f"Expected dictionary response but got " f"{type(response_data).__name__}: {response_data}"
             self.logger.error(error_msg)
             raise FogisDataError(error_msg)
 
-    def fetch_match_result_json(
-        self, match_id: Union[str, int]
-    ) -> Union[MatchResultDict, List[MatchResultDict]]:
+    def fetch_match_result_json(self, match_id: Union[str, int]) -> Union[MatchResultDict, List[MatchResultDict]]:
         """
         Fetches the match results in JSON format for a given match ID.
 
@@ -756,9 +710,7 @@ class FogisApiClient:
             ...     print(f"Multiple results found: {len(result)}")
             Score: 2-1
         """
-        result_url = (
-            f"{FogisApiClient.BASE_URL}/MatchWebMetoder.aspx/GetMatchresultatlista"
-        )
+        result_url = f"{FogisApiClient.BASE_URL}/MatchWebMetoder.aspx/GetMatchresultatlista"
         match_id_int = int(match_id) if isinstance(match_id, (str, int)) else match_id
         payload = {"matchid": match_id_int}
 
@@ -769,10 +721,7 @@ class FogisApiClient:
         elif isinstance(response_data, list):
             return cast(List[MatchResultDict], response_data)
         else:
-            error_msg = (
-                f"Expected dictionary or list response but got "
-                f"{type(response_data).__name__}: {response_data}"
-            )
+            error_msg = f"Expected dictionary or list response but got " f"{type(response_data).__name__}: {response_data}"
             self.logger.error(error_msg)
             raise FogisDataError(error_msg)
 
@@ -838,18 +787,13 @@ class FogisApiClient:
                 elif isinstance(value, int):
                     result_data_copy[field] = value
 
-        result_url = (
-            f"{FogisApiClient.BASE_URL}/MatchWebMetoder.aspx/SparaMatchresultatLista"
-        )
+        result_url = f"{FogisApiClient.BASE_URL}/MatchWebMetoder.aspx/SparaMatchresultatLista"
         response_data = self._api_request(result_url, result_data_copy)
 
         if isinstance(response_data, dict):
             return response_data
         else:
-            error_msg = (
-                f"Expected dictionary response but got "
-                f"{type(response_data).__name__}: {response_data}"
-            )
+            error_msg = f"Expected dictionary response but got " f"{type(response_data).__name__}: {response_data}"
             self.logger.error(error_msg)
             raise FogisDataError(error_msg)
 
@@ -902,18 +846,14 @@ class FogisApiClient:
                     self.logger.warning(f"Failed to delete event with ID {event_id}")
                 return success
             else:
-                self.logger.warning(
-                    f"Unexpected response format when deleting event with ID {event_id}"
-                )
+                self.logger.warning(f"Unexpected response format when deleting event with ID {event_id}")
                 return False
 
         except (FogisAPIRequestError, FogisDataError) as e:
             self.logger.error(f"Error deleting event with ID {event_id}: {e}")
             return False
 
-    def report_team_official_action(
-        self, action_data: OfficialActionDict
-    ) -> Dict[str, Any]:
+    def report_team_official_action(self, action_data: OfficialActionDict) -> Dict[str, Any]:
         """
         Reports team official disciplinary action to the FOGIS API.
 
@@ -971,18 +911,13 @@ class FogisApiClient:
                 elif isinstance(value, int):
                     action_data_copy[key] = value
 
-        action_url = (
-            f"{FogisApiClient.BASE_URL}/MatchWebMetoder.aspx/SparaMatchlagledare"
-        )
+        action_url = f"{FogisApiClient.BASE_URL}/MatchWebMetoder.aspx/SparaMatchlagledare"
         response_data = self._api_request(action_url, action_data_copy)
 
         if isinstance(response_data, dict):
             return response_data
         else:
-            error_msg = (
-                f"Expected dictionary response but got "
-                f"{type(response_data).__name__}: {response_data}"
-            )
+            error_msg = f"Expected dictionary response but got " f"{type(response_data).__name__}: {response_data}"
             self.logger.error(error_msg)
             raise FogisDataError(error_msg)
 
@@ -1019,17 +954,12 @@ class FogisApiClient:
 
         if isinstance(response_data, dict):
             if response_data.get("success", False):
-                self.logger.info(
-                    f"Successfully cleared all events for match ID {match_id}"
-                )
+                self.logger.info(f"Successfully cleared all events for match ID {match_id}")
             else:
                 self.logger.warning(f"Failed to clear events for match ID {match_id}")
             return cast(Dict[str, bool], response_data)
         else:
-            error_msg = (
-                f"Expected dictionary response but got "
-                f"{type(response_data).__name__}: {response_data}"
-            )
+            error_msg = f"Expected dictionary response but got " f"{type(response_data).__name__}: {response_data}"
             self.logger.error(error_msg)
             raise FogisDataError(error_msg)
 
@@ -1117,6 +1047,205 @@ class FogisApiClient:
             self.logger.debug("No cookies available to return")
         return self.cookies
 
+    def save_match_participant(self, participant_data: MatchParticipantDict) -> Dict[str, Any]:
+        """
+        Updates specific fields for a match participant in FOGIS while preserving other fields.
+
+        This method is used to modify only the fields you specify (like jersey number, captain status, etc.)
+        while keeping all other player information unchanged. You identify the player using their
+        match-specific ID (matchdeltagareid), and provide only the fields you want to update.
+
+        The method returns the updated team roster and verifies that your requested changes were applied.
+
+        Args:
+            participant_data: Data containing match participant details. Must include:
+                - matchdeltagareid: The ID of the match participant
+                - trojnummer: Jersey number
+                - lagdelid: Team part ID (typically 0)
+                - lagkapten: Boolean indicating if the player is team captain
+                - ersattare: Boolean indicating if the player is a substitute
+                - positionsnummerhv: Position number (typically 0)
+                - arSpelandeLedare: Boolean indicating if the player is a playing leader
+                - ansvarig: Boolean indicating if the player is responsible
+
+        Returns:
+            Dict[str, Any]: Response from the API containing:
+                - success: Boolean indicating if the update was successful
+                - roster: The updated team roster
+                - updated_player: The updated player information
+                - verified: Boolean indicating if the changes were verified in the returned roster
+
+        Raises:
+            FogisLoginError: If not logged in
+            FogisAPIRequestError: If there's an error with the API request
+            FogisDataError: If the response data is invalid or not a dictionary
+            ValueError: If required fields are missing
+
+        Examples:
+            >>> client = FogisApiClient(username="your_username", password="your_password")
+            >>> # Update a player's jersey number and set as captain
+            >>> participant = {
+            ...     "matchdeltagareid": 46123762,
+            ...     "trojnummer": 10,
+            ...     "lagkapten": True,
+            ...     "ersattare": False,
+            ...     "lagdelid": 0,
+            ...     "positionsnummerhv": 0,
+            ...     "arSpelandeLedare": False,
+            ...     "ansvarig": False
+            ... }
+            >>> response = client.save_match_participant(participant)
+            >>> if response["success"] and response["verified"]:
+            ...     print(f"Player updated successfully with jersey #{response['updated_player']['trojnummer']}")
+            ... else:
+            ...     print("Update failed or changes not verified")
+            Player updated successfully with jersey #10
+        """
+        url = f"{FogisApiClient.BASE_URL}/MatchWebMetoder.aspx/SparaMatchdeltagare"
+
+        # IMPORTANT: We use matchdeltagareid (match participant ID) here, NOT spelareid (player ID).
+        # matchdeltagareid is a temporary ID for a player in a specific match, while
+        # spelareid is the permanent ID for a player in the FOGIS system.
+        # When updating player information for a specific match, we must use matchdeltagareid.
+
+        # Ensure required fields are present
+        required_fields = [
+            "matchdeltagareid",  # Match-specific player ID (not the permanent spelareid)
+            "trojnummer",
+            "lagdelid",
+            "lagkapten",
+            "ersattare",
+            "positionsnummerhv",
+            "arSpelandeLedare",
+            "ansvarig",
+        ]
+        for field in required_fields:
+            if field not in participant_data:
+                error_msg = f"Missing required field '{field}' in participant data"
+                self.logger.error(error_msg)
+                raise ValueError(error_msg)
+
+        # Create a copy to avoid modifying the original
+        participant_data_copy = dict(participant_data)
+
+        # Ensure numeric fields are integers and boolean fields are booleans
+        for field in ["matchdeltagareid", "trojnummer", "lagdelid", "positionsnummerhv"]:
+            if field in participant_data_copy and participant_data_copy[field] is not None:
+                value = participant_data_copy[field]
+                if isinstance(value, str):
+                    participant_data_copy[field] = int(value)
+                elif isinstance(value, int):
+                    participant_data_copy[field] = value
+
+        # Ensure boolean fields are booleans
+        for field in ["lagkapten", "ersattare", "arSpelandeLedare", "ansvarig"]:
+            if field in participant_data_copy and participant_data_copy[field] is not None:
+                value = participant_data_copy[field]
+                if isinstance(value, str):
+                    participant_data_copy[field] = value.lower() == "true"
+                elif not isinstance(value, bool):
+                    participant_data_copy[field] = bool(value)
+
+        # Store the expected values for verification
+        expected_values = {
+            "trojnummer": participant_data_copy["trojnummer"],
+            "lagkapten": participant_data_copy["lagkapten"],
+            "ersattare": participant_data_copy["ersattare"],
+        }
+        player_id = participant_data_copy["matchdeltagareid"]
+
+        self.logger.info(f"Updating match participant with ID {player_id}")
+        response_data = self._api_request(url, participant_data_copy)
+
+        # Prepare the result dictionary
+        result = {"success": False, "roster": None, "updated_player": None, "verified": False}
+
+        if isinstance(response_data, dict):
+            # The API returns the updated team roster
+            result["success"] = True
+            result["roster"] = response_data
+
+            # Try to find the updated player in the roster
+            updated_player = None
+            if "spelare" in response_data and isinstance(response_data["spelare"], list):
+                for player in response_data["spelare"]:
+                    # First try to match by matchdeltagareid (preferred)
+                    if player.get("matchdeltagareid") == player_id:
+                        updated_player = player
+                        break
+
+                # If we couldn't find by matchdeltagareid, try to find by other identifiers
+                # This is a fallback in case the API returns different ID fields
+                if not updated_player and len(response_data["spelare"]) > 0:
+                    self.logger.warning(
+                        f"Could not find player with matchdeltagareid={player_id} in response. "
+                        f"Checking for other identifiers."
+                    )
+
+                    # If the API returned spelareid instead of matchdeltagareid
+                    # We'll need to rely on other fields like jersey number to identify the player
+                    expected_jersey = participant_data_copy["trojnummer"]
+                    for player in response_data["spelare"]:
+                        jersey = player.get("trojnummer")
+                        if jersey is not None:
+                            # Convert to int if it's a string
+                            if isinstance(jersey, str):
+                                try:
+                                    jersey = int(jersey)
+                                except (ValueError, TypeError):
+                                    pass
+
+                            if jersey == expected_jersey:
+                                self.logger.info(
+                                    f"Found player with matching jersey number {expected_jersey} "
+                                    f"instead of matchdeltagareid"
+                                )
+                                updated_player = player
+                                break
+
+            if updated_player:
+                result["updated_player"] = updated_player
+
+                # Verify that our changes were applied
+                verified = True
+                for field, expected_value in expected_values.items():
+                    if field in updated_player:
+                        actual_value = updated_player[field]
+                        # Convert string values if needed
+                        if field == "trojnummer" and isinstance(actual_value, str):
+                            try:
+                                actual_value = int(actual_value)
+                            except (ValueError, TypeError):
+                                pass
+                        # For boolean fields that might be returned as strings
+                        if field in ["lagkapten", "ersattare"] and isinstance(actual_value, str):
+                            actual_value = actual_value.lower() == "true"
+
+                        if actual_value != expected_value:
+                            self.logger.warning(
+                                f"Field '{field}' was not updated correctly. "
+                                f"Expected: {expected_value}, Got: {actual_value}"
+                            )
+                            verified = False
+                    else:
+                        self.logger.warning(f"Field '{field}' not found in updated player data")
+                        verified = False
+
+                result["verified"] = verified
+
+                if verified:
+                    self.logger.info(f"Successfully verified update for player with ID {player_id}")
+                else:
+                    self.logger.warning(f"Could not verify all updates for player with ID {player_id}")
+            else:
+                self.logger.warning(f"Updated player with ID {player_id} not found in response roster")
+
+            return result
+        else:
+            error_msg = f"Expected dictionary response but got " f"{type(response_data).__name__}: {response_data}"
+            self.logger.error(error_msg)
+            raise FogisDataError(error_msg)
+
     def hello_world(self) -> str:
         """
         Simple test method.
@@ -1177,19 +1306,12 @@ class FogisApiClient:
 
         if isinstance(response_data, dict):
             if response_data.get("success", False):
-                self.logger.info(
-                    f"Successfully marked match ID {match_id} reporting as finished"
-                )
+                self.logger.info(f"Successfully marked match ID {match_id} reporting as finished")
             else:
-                self.logger.warning(
-                    f"Failed to mark match ID {match_id} reporting as finished"
-                )
+                self.logger.warning(f"Failed to mark match ID {match_id} reporting as finished")
             return cast(Dict[str, bool], response_data)
         else:
-            error_msg = (
-                f"Expected dictionary response but got "
-                f"{type(response_data).__name__}: {response_data}"
-            )
+            error_msg = f"Expected dictionary response but got " f"{type(response_data).__name__}: {response_data}"
             self.logger.error(error_msg)
             raise FogisDataError(error_msg)
 
@@ -1215,12 +1337,7 @@ class FogisApiClient:
             ValueError: If an unsupported HTTP method is specified
         """
         # For tests only - mock response for specific URLs
-        if (
-            self.username
-            and isinstance(self.username, str)
-            and "test" in self.username
-            and url.endswith("HamtaMatchLista")
-        ):
+        if self.username and isinstance(self.username, str) and "test" in self.username and url.endswith("HamtaMatchLista"):
             self.logger.debug("Using test mock for match list")
             return {"matcher": []}
 
@@ -1250,9 +1367,7 @@ class FogisApiClient:
 
         # Add cookies to headers if available
         if self.cookies:
-            api_headers["Cookie"] = "; ".join(
-                [f"{key}={value}" for key, value in self.cookies.items()]
-            )
+            api_headers["Cookie"] = "; ".join([f"{key}={value}" for key, value in self.cookies.items()])
 
         try:
             self.logger.debug(f"Making {method} request to {url}")
@@ -1279,20 +1394,14 @@ class FogisApiClient:
                         return json.loads(response_json["d"])
                     except json.JSONDecodeError:
                         # If it's not valid JSON, return as is
-                        self.logger.debug(
-                            "Response 'd' value is not valid JSON, returning as string"
-                        )
+                        self.logger.debug("Response 'd' value is not valid JSON, returning as string")
                         return response_json["d"]
                 else:
                     # If 'd' is already a dict/list, return it directly
-                    self.logger.debug(
-                        "Response 'd' value is already parsed, returning directly"
-                    )
+                    self.logger.debug("Response 'd' value is already parsed, returning directly")
                     return response_json["d"]
             else:
-                self.logger.debug(
-                    "Response does not contain 'd' key, returning full response"
-                )
+                self.logger.debug("Response does not contain 'd' key, returning full response")
                 return response_json
 
         except requests.exceptions.RequestException as e:

--- a/fogis_api_client/types.py
+++ b/fogis_api_client/types.py
@@ -121,3 +121,16 @@ class CookieDict(TypedDict, total=False):
 
     FogisMobilDomarKlient_ASPXAUTH: str
     ASP_NET_SessionId: str
+
+
+class MatchParticipantDict(TypedDict, total=False):
+    """Type definition for a match participant update used in reporting."""
+
+    matchdeltagareid: int
+    trojnummer: int
+    lagdelid: int
+    lagkapten: bool
+    ersattare: bool
+    positionsnummerhv: int
+    arSpelandeLedare: bool
+    ansvarig: bool

--- a/integration_tests/mock_fogis_server.py
+++ b/integration_tests/mock_fogis_server.py
@@ -7,6 +7,7 @@ for integration testing without requiring real credentials or internet access.
 
 import json
 import logging
+import random
 from datetime import datetime
 from typing import Dict, List
 
@@ -60,12 +61,8 @@ class MockFogisServer:
         def login():
             if request.method == "POST":
                 # Try both field name formats
-                username = request.form.get("ctl00$cphMain$tbUsername") or request.form.get(
-                    "ctl00$MainContent$UserName"
-                )
-                password = request.form.get("ctl00$cphMain$tbPassword") or request.form.get(
-                    "ctl00$MainContent$Password"
-                )
+                username = request.form.get("ctl00$cphMain$tbUsername") or request.form.get("ctl00$MainContent$UserName")
+                password = request.form.get("ctl00$cphMain$tbPassword") or request.form.get("ctl00$MainContent$Password")
 
                 if username in self.users and self.users[username] == password:
                     # Successful login
@@ -276,9 +273,7 @@ class MockFogisServer:
             return jsonify({"d": json.dumps({"success": True})})
 
         # Team players endpoint
-        @self.app.route(
-            "/mdk/MatchWebMetoder.aspx/GetMatchdeltagareListaForMatchlag", methods=["POST"]
-        )
+        @self.app.route("/mdk/MatchWebMetoder.aspx/GetMatchdeltagareListaForMatchlag", methods=["POST"])
         def fetch_team_players_endpoint():
             auth_result = self._check_auth()
             if auth_result is not True:
@@ -295,9 +290,7 @@ class MockFogisServer:
             return jsonify({"d": json.dumps(players_data)})
 
         # Team officials endpoint
-        @self.app.route(
-            "/mdk/MatchWebMetoder.aspx/GetMatchlagledareListaForMatchlag", methods=["POST"]
-        )
+        @self.app.route("/mdk/MatchWebMetoder.aspx/GetMatchlagledareListaForMatchlag", methods=["POST"])
         def fetch_team_officials_endpoint():
             auth_result = self._check_auth()
             if auth_result is not True:
@@ -314,9 +307,7 @@ class MockFogisServer:
             return jsonify({"d": json.dumps(officials_data)})
 
         # Match details endpoint
-        @self.app.route(
-            "/mdk/MatchWebMetoder.aspx/GetMatch", methods=["POST"]
-        )
+        @self.app.route("/mdk/MatchWebMetoder.aspx/GetMatch", methods=["POST"])
         def fetch_match_details_endpoint():
             auth_result = self._check_auth()
             if auth_result is not True:
@@ -333,9 +324,7 @@ class MockFogisServer:
             return jsonify({"d": json.dumps(match_data)})
 
         # Match players endpoint
-        @self.app.route(
-            "/mdk/MatchWebMetoder.aspx/GetMatchdeltagareLista", methods=["POST"]
-        )
+        @self.app.route("/mdk/MatchWebMetoder.aspx/GetMatchdeltagareLista", methods=["POST"])
         def fetch_match_players_endpoint():
             auth_result = self._check_auth()
             if auth_result is not True:
@@ -352,9 +341,7 @@ class MockFogisServer:
             return jsonify({"d": json.dumps(players_data)})
 
         # Match officials endpoint
-        @self.app.route(
-            "/mdk/MatchWebMetoder.aspx/GetMatchfunktionarerLista", methods=["POST"]
-        )
+        @self.app.route("/mdk/MatchWebMetoder.aspx/GetMatchfunktionarerLista", methods=["POST"])
         def fetch_match_officials_endpoint():
             auth_result = self._check_auth()
             if auth_result is not True:
@@ -371,9 +358,7 @@ class MockFogisServer:
             return jsonify({"d": json.dumps(officials_data)})
 
         # Match events endpoint
-        @self.app.route(
-            "/mdk/MatchWebMetoder.aspx/GetMatchhandelselista", methods=["POST"]
-        )
+        @self.app.route("/mdk/MatchWebMetoder.aspx/GetMatchhandelselista", methods=["POST"])
         def fetch_match_events_endpoint():
             auth_result = self._check_auth()
             if auth_result is not True:
@@ -390,9 +375,7 @@ class MockFogisServer:
             return jsonify({"d": json.dumps(events_data)})
 
         # Match result endpoint
-        @self.app.route(
-            "/mdk/MatchWebMetoder.aspx/GetMatchresultat", methods=["POST"]
-        )
+        @self.app.route("/mdk/MatchWebMetoder.aspx/GetMatchresultat", methods=["POST"])
         def fetch_match_result_endpoint():
             auth_result = self._check_auth()
             if auth_result is not True:
@@ -409,9 +392,7 @@ class MockFogisServer:
             return jsonify({"d": json.dumps(result_data)})
 
         # Clear match events endpoint
-        @self.app.route(
-            "/mdk/MatchWebMetoder.aspx/ClearMatchEvents", methods=["POST"]
-        )
+        @self.app.route("/mdk/MatchWebMetoder.aspx/ClearMatchEvents", methods=["POST"])
         def clear_match_events_endpoint():
             auth_result = self._check_auth()
             if auth_result is not True:
@@ -421,9 +402,7 @@ class MockFogisServer:
             return jsonify({"d": json.dumps({"success": True})})
 
         # Report match event endpoint
-        @self.app.route(
-            "/mdk/MatchWebMetoder.aspx/SparaMatchhandelse", methods=["POST"]
-        )
+        @self.app.route("/mdk/MatchWebMetoder.aspx/SparaMatchhandelse", methods=["POST"])
         def report_match_event_endpoint():
             auth_result = self._check_auth()
             if auth_result is not True:
@@ -433,9 +412,7 @@ class MockFogisServer:
             return jsonify({"d": json.dumps({"success": True})})
 
         # Mark reporting finished endpoint
-        @self.app.route(
-            "/mdk/MatchWebMetoder.aspx/SparaMatchGodkannDomarrapport", methods=["POST"]
-        )
+        @self.app.route("/mdk/MatchWebMetoder.aspx/SparaMatchGodkannDomarrapport", methods=["POST"])
         def mark_reporting_finished_endpoint():
             auth_result = self._check_auth()
             if auth_result is not True:
@@ -443,6 +420,58 @@ class MockFogisServer:
 
             # Return success response
             return jsonify({"d": json.dumps({"success": True})})
+
+        # Save match participant endpoint
+        @self.app.route("/mdk/MatchWebMetoder.aspx/SparaMatchdeltagare", methods=["POST"])
+        def save_match_participant_endpoint():
+            auth_result = self._check_auth()
+            if auth_result is not True:
+                return auth_result
+
+            # Get participant data from request
+            data = request.json or {}
+            match_deltagare_id = data.get("matchdeltagareid")
+
+            if not match_deltagare_id:
+                return jsonify({"d": json.dumps({"error": "Missing matchdeltagareid"})}), 400
+
+            # Generate a team roster with the updated player
+            team_id = random.randint(10000, 99999)  # Generate a random team ID
+            roster = MockDataFactory.generate_team_players(team_id)
+
+            # Find or create the player with the specified matchdeltagareid
+            updated_player = None
+            for player in roster["spelare"]:
+                if random.random() < 0.2:  # 20% chance to match this player
+                    # Update this player to match the requested changes
+                    player["matchdeltagareid"] = match_deltagare_id
+                    player["trojnummer"] = data.get("trojnummer", player.get("tshirt", 0))
+                    player["lagkapten"] = data.get("lagkapten", False)
+                    player["ersattare"] = data.get("ersattare", False)
+                    updated_player = player
+                    break
+
+            # If we didn't find a player to update, add one
+            if not updated_player:
+                new_player = {
+                    "matchdeltagareid": match_deltagare_id,
+                    "personid": MockDataFactory.generate_id(),
+                    "fornamn": MockDataFactory.generate_name(True),
+                    "efternamn": MockDataFactory.generate_name(False),
+                    "trojnummer": data.get("trojnummer", random.randint(1, 99)),
+                    "lagkapten": data.get("lagkapten", False),
+                    "ersattare": data.get("ersattare", False),
+                    "position": random.choice(["Målvakt", "Försvarare", "Mittfältare", "Anfallare"]),
+                    "matchlagid": team_id,
+                    "fodelsedatum": MockDataFactory.generate_date(False),
+                    "licensnummer": f"LIC{random.randint(100000, 999999)}",
+                    "spelarregistreringsstrang": "",
+                    "spelareAntalAckumuleradeVarningar": random.randint(0, 2),
+                    "spelareAvstangningBeskrivning": "",
+                }
+                roster["spelare"].append(new_player)
+
+            return jsonify({"d": json.dumps(roster)})
 
         # Main dashboard route after login
         @self.app.route("/mdk/", methods=["GET"])

--- a/integration_tests/test_with_mock_server.py
+++ b/integration_tests/test_with_mock_server.py
@@ -20,9 +20,7 @@ logger = logging.getLogger(__name__)
 class TestFogisApiClientWithMockServer:
     """Integration tests for the FogisApiClient using a mock server."""
 
-    def test_login_success(
-        self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]
-    ):
+    def test_login_success(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
         """Test successful login with valid credentials."""
         # Override the base URL to use the mock server
         FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
@@ -58,9 +56,7 @@ class TestFogisApiClientWithMockServer:
         with pytest.raises(FogisLoginError):
             client.login()
 
-    def test_fetch_matches_list(
-        self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]
-    ):
+    def test_fetch_matches_list(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
         """Test fetching the match list."""
         # Override the base URL to use the mock server
         FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
@@ -108,9 +104,7 @@ class TestFogisApiClientWithMockServer:
         assert "datum" in match
         assert "tid" in match
 
-    def test_fetch_match_details(
-        self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]
-    ):
+    def test_fetch_match_details(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
         """Test fetching match details."""
         # Override the base URL to use the mock server
         FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
@@ -133,9 +127,7 @@ class TestFogisApiClientWithMockServer:
         assert "datum" in match
         assert "tid" in match
 
-    def test_fetch_match_players(
-        self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]
-    ):
+    def test_fetch_match_players(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
         """Test fetching match players."""
         # Override the base URL to use the mock server
         FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
@@ -169,9 +161,7 @@ class TestFogisApiClientWithMockServer:
         assert "fornamn" in home_player
         assert "efternamn" in home_player
 
-    def test_fetch_match_officials(
-        self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]
-    ):
+    def test_fetch_match_officials(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
         """Test fetching match officials."""
         # Override the base URL to use the mock server
         FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
@@ -206,9 +196,7 @@ class TestFogisApiClientWithMockServer:
         assert "fornamn" in home_official
         assert "efternamn" in home_official
 
-    def test_fetch_match_events(
-        self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]
-    ):
+    def test_fetch_match_events(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
         """Test fetching match events."""
         # Override the base URL to use the mock server
         FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
@@ -236,9 +224,7 @@ class TestFogisApiClientWithMockServer:
         assert "matchminut" in event  # New field name instead of minut
         assert "matchlagid" in event  # New field name instead of lagid
 
-    def test_fetch_match_result(
-        self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]
-    ):
+    def test_fetch_match_result(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
         """Test fetching match result."""
         # Override the base URL to use the mock server
         FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
@@ -267,9 +253,7 @@ class TestFogisApiClientWithMockServer:
             assert "matchlag1mal" in result[0]
             assert "matchlag2mal" in result[0]
 
-    def test_report_match_event(
-        self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]
-    ):
+    def test_report_match_event(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
         """Test reporting a match event."""
         # Override the base URL to use the mock server
         FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
@@ -307,9 +291,7 @@ class TestFogisApiClientWithMockServer:
         assert "success" in response
         assert response["success"] is True
 
-    def test_clear_match_events(
-        self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]
-    ):
+    def test_clear_match_events(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
         """Test clearing match events."""
         # Override the base URL to use the mock server
         FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
@@ -329,9 +311,7 @@ class TestFogisApiClientWithMockServer:
         assert "success" in response
         assert response["success"] is True
 
-    def test_mark_reporting_finished(
-        self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]
-    ):
+    def test_mark_reporting_finished(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
         """Test marking reporting as finished."""
         # Override the base URL to use the mock server
         FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
@@ -368,9 +348,7 @@ class TestFogisApiClientWithMockServer:
         # Verify the response
         assert message == "Hello, brave new world!"
 
-    def test_fetch_team_players(
-        self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]
-    ):
+    def test_fetch_team_players(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
         """Test fetching team players."""
         # Override the base URL to use the mock server
         FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
@@ -401,9 +379,7 @@ class TestFogisApiClientWithMockServer:
         assert "matchlagid" in player  # type: ignore
         assert player["matchlagid"] == team_id  # type: ignore
 
-    def test_fetch_team_officials(
-        self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]
-    ):
+    def test_fetch_team_officials(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
         """Test fetching team officials."""
         # Override the base URL to use the mock server
         FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
@@ -457,3 +433,47 @@ class TestFogisApiClientWithMockServer:
         # For this test, we'll skip the actual API call and just verify the cookies
         # This is because the mock server cookie handling is complex to match exactly
         # what the real server does
+
+    def test_save_match_participant(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
+        """Test saving match participant information."""
+        # Override the base URL to use the mock server
+        FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
+
+        # Create a client with test credentials
+        client = FogisApiClient(
+            username=test_credentials["username"],
+            password=test_credentials["password"],
+        )
+
+        # Login to get cookies
+        client.login()
+
+        # Create participant data to update
+        participant_data = {
+            "matchdeltagareid": 46123762,
+            "trojnummer": 10,
+            "lagdelid": 0,
+            "lagkapten": True,
+            "ersattare": False,
+            "positionsnummerhv": 0,
+            "arSpelandeLedare": False,
+            "ansvarig": False,
+        }
+
+        # Save match participant
+        response = client.save_match_participant(participant_data)
+
+        # Verify the response structure
+        assert response["success"] is True
+        assert "roster" in response
+        assert "updated_player" in response
+
+        # The verification might be True or False depending on the mock server's random behavior
+        # but it should be a boolean
+        assert isinstance(response["verified"], bool)
+
+        # If verification succeeded, check the updated player
+        if response["verified"] and response["updated_player"]:
+            assert response["updated_player"]["matchdeltagareid"] == participant_data["matchdeltagareid"]
+            assert response["updated_player"]["trojnummer"] == participant_data["trojnummer"]
+            assert response["updated_player"]["lagkapten"] == participant_data["lagkapten"]

--- a/tests/test_fogis_api_client.py
+++ b/tests/test_fogis_api_client.py
@@ -5,11 +5,7 @@ from unittest.mock import MagicMock, Mock
 
 import requests
 
-from fogis_api_client.fogis_api_client import (
-    FogisApiClient,
-    FogisAPIRequestError,
-    FogisLoginError,
-)
+from fogis_api_client.fogis_api_client import FogisApiClient, FogisAPIRequestError, FogisLoginError
 
 
 class MockResponse:
@@ -28,9 +24,7 @@ class MockResponse:
 
     def raise_for_status(self):
         if 400 <= self.status_code < 600:
-            raise requests.exceptions.HTTPError(
-                f"HTTP Error {self.status_code}", response=self
-            )
+            raise requests.exceptions.HTTPError(f"HTTP Error {self.status_code}", response=self)
 
 
 class TestFogisApiClient(unittest.TestCase):
@@ -48,9 +42,7 @@ class TestFogisApiClient(unittest.TestCase):
         mock_session.cookies.set = MagicMock()
 
         self.client.session = mock_session
-        self.client.cookies = {
-            "FogisMobilDomarKlient.ASPXAUTH": "mock_auth_cookie"
-        }  # Simulate being logged in
+        self.client.cookies = {"FogisMobilDomarKlient.ASPXAUTH": "mock_auth_cookie"}  # Simulate being logged in
 
         # Set up logging capture
         self.log_capture = io.StringIO()
@@ -85,9 +77,7 @@ class TestFogisApiClient(unittest.TestCase):
         mock_post_response = Mock()
         mock_post_response.status_code = 302
         mock_post_response.headers = {"Location": "/mdk/"}
-        mock_post_response.cookies = {
-            "FogisMobilDomarKlient.ASPXAUTH": "mock_auth_cookie"
-        }
+        mock_post_response.cookies = {"FogisMobilDomarKlient.ASPXAUTH": "mock_auth_cookie"}
         mocked_session.post.return_value = mock_post_response
 
         # Mock the redirect response
@@ -103,9 +93,7 @@ class TestFogisApiClient(unittest.TestCase):
         # Verify the result
         self.assertIn("FogisMobilDomarKlient.ASPXAUTH", cookies)
         self.assertEqual(cookies["FogisMobilDomarKlient.ASPXAUTH"], "mock_auth_cookie")
-        self.assertEqual(
-            mocked_session.get.call_count, 2
-        )  # Initial page load + redirect
+        self.assertEqual(mocked_session.get.call_count, 2)  # Initial page load + redirect
         mocked_session.post.assert_called_once()
 
     def test_login_failure_invalid_credentials(self):
@@ -212,9 +200,7 @@ class TestFogisApiClient(unittest.TestCase):
         # Create a mock response that raises an HTTP error
         mock_api_response = MockResponse({"error": "Not found"}, 404)
         mock_session_instance.post.return_value = mock_api_response
-        mock_api_response.raise_for_status = MagicMock(
-            side_effect=requests.exceptions.HTTPError("HTTP Error 404")
-        )
+        mock_api_response.raise_for_status = MagicMock(side_effect=requests.exceptions.HTTPError("HTTP Error 404"))
 
         # Call _api_request and expect an exception
         with self.assertRaises(FogisAPIRequestError) as excinfo:
@@ -267,9 +253,7 @@ class TestFogisApiClient(unittest.TestCase):
     def test_fetch_matches_list_json_success(self):
         """Unit test for fetch_matches_list_json success."""
         # Mock the _api_request method
-        self.client._api_request = MagicMock(
-            return_value={"matchlista": [{"matchid": 1}, {"matchid": 2}]}
-        )
+        self.client._api_request = MagicMock(return_value={"matchlista": [{"matchid": 1}, {"matchid": 2}]})
 
         # Call fetch_matches_list_json
         matches_list = self.client.fetch_matches_list_json()
@@ -388,11 +372,7 @@ class TestFogisApiClient(unittest.TestCase):
     def test_fetch_match_result_json(self):
         """Unit test for fetch_match_result_json method."""
         # Mock the _api_request method
-        self.client._api_request = MagicMock(
-            return_value=[
-                {"matchresultattypid": 1, "matchlag1mal": 2, "matchlag2mal": 1}
-            ]
-        )
+        self.client._api_request = MagicMock(return_value=[{"matchresultattypid": 1, "matchlag1mal": 2, "matchlag2mal": 1}])
 
         # Call fetch_match_result_json
         match_id = 12345
@@ -414,9 +394,7 @@ class TestFogisApiClient(unittest.TestCase):
         """Unit test for fetch_match_result_json method with error."""
         # Mock the _api_request method to raise an exception
         error_msg = "API request failed"
-        self.client._api_request = MagicMock(
-            side_effect=FogisAPIRequestError(error_msg)
-        )
+        self.client._api_request = MagicMock(side_effect=FogisAPIRequestError(error_msg))
 
         # Call fetch_match_result_json and expect an exception
         with self.assertRaises(FogisAPIRequestError) as excinfo:
@@ -465,9 +443,7 @@ class TestFogisApiClient(unittest.TestCase):
         """Unit test for report_match_result method with error."""
         # Mock the _api_request method to raise an exception
         error_msg = "API request failed"
-        self.client._api_request = MagicMock(
-            side_effect=FogisAPIRequestError(error_msg)
-        )
+        self.client._api_request = MagicMock(side_effect=FogisAPIRequestError(error_msg))
 
         # Call report_match_result and expect an exception
         result_data = {"matchid": "12345", "hemmamal": 2, "bortamal": 1}
@@ -547,9 +523,7 @@ class TestFogisApiClient(unittest.TestCase):
         """Unit test for report_team_official_action method with error."""
         # Mock the _api_request method to raise an exception
         error_msg = "API request failed"
-        self.client._api_request = MagicMock(
-            side_effect=FogisAPIRequestError(error_msg)
-        )
+        self.client._api_request = MagicMock(side_effect=FogisAPIRequestError(error_msg))
 
         # Call report_team_official_action and expect an exception
         action_data = {
@@ -573,6 +547,208 @@ class TestFogisApiClient(unittest.TestCase):
                 "lagid": 67890,  # Should be converted to int
                 "personid": 54321,  # Should be converted to int
                 "matchlagledaretypid": 2,  # Should be converted to int
+            },
+        )
+
+    def test_save_match_participant(self):
+        """Unit test for save_match_participant method."""
+        # Mock the _api_request method with a roster response
+        mock_response = {
+            "spelare": [
+                {
+                    "matchdeltagareid": 46123762,
+                    "fornamn": "John",
+                    "efternamn": "Doe",
+                    "trojnummer": 92,
+                    "lagkapten": False,
+                    "ersattare": False,
+                },
+                {
+                    "matchdeltagareid": 46123763,
+                    "fornamn": "Jane",
+                    "efternamn": "Smith",
+                    "trojnummer": 10,
+                    "lagkapten": True,
+                    "ersattare": False,
+                },
+            ]
+        }
+        self.client._api_request = MagicMock(return_value=mock_response)
+
+        # Call save_match_participant
+        participant_data = {
+            "matchdeltagareid": "46123762",
+            "trojnummer": "92",
+            "lagdelid": "0",
+            "lagkapten": "false",
+            "ersattare": "false",
+            "positionsnummerhv": "0",
+            "arSpelandeLedare": "false",
+            "ansvarig": "false",
+        }
+        response = self.client.save_match_participant(participant_data)
+
+        # Verify the result structure
+        self.assertTrue(response["success"])
+        self.assertTrue(response["verified"])
+        self.assertEqual(response["roster"], mock_response)
+        self.assertEqual(response["updated_player"]["matchdeltagareid"], 46123762)
+        self.assertEqual(response["updated_player"]["trojnummer"], 92)
+        self.assertEqual(response["updated_player"]["lagkapten"], False)
+
+        # Verify the API call
+        self.client._api_request.assert_called_once_with(
+            f"{FogisApiClient.BASE_URL}/MatchWebMetoder.aspx/SparaMatchdeltagare",
+            {
+                "matchdeltagareid": 46123762,  # Should be converted to int
+                "trojnummer": 92,  # Should be converted to int
+                "lagdelid": 0,  # Should be converted to int
+                "lagkapten": False,  # Should be converted to bool
+                "ersattare": False,  # Should be converted to bool
+                "positionsnummerhv": 0,  # Should be converted to int
+                "arSpelandeLedare": False,  # Should be converted to bool
+                "ansvarig": False,  # Should be converted to bool
+            },
+        )
+
+    def test_save_match_participant_error(self):
+        """Unit test for save_match_participant method with error."""
+        # Mock the _api_request method to raise an exception
+        error_msg = "API request failed"
+        self.client._api_request = MagicMock(side_effect=FogisAPIRequestError(error_msg))
+
+        # Call save_match_participant and expect an exception
+        participant_data = {
+            "matchdeltagareid": "46123762",
+            "trojnummer": "92",
+            "lagdelid": "0",
+            "lagkapten": "false",
+            "ersattare": "false",
+            "positionsnummerhv": "0",
+            "arSpelandeLedare": "false",
+            "ansvarig": "false",
+        }
+        with self.assertRaises(FogisAPIRequestError) as excinfo:
+            self.client.save_match_participant(participant_data)
+
+        # Verify the exception message
+        self.assertIn("API request failed", str(excinfo.exception))
+
+        # Verify the API call
+        self.client._api_request.assert_called_once_with(
+            f"{FogisApiClient.BASE_URL}/MatchWebMetoder.aspx/SparaMatchdeltagare",
+            {
+                "matchdeltagareid": 46123762,  # Should be converted to int
+                "trojnummer": 92,  # Should be converted to int
+                "lagdelid": 0,  # Should be converted to int
+                "lagkapten": False,  # Should be converted to bool
+                "ersattare": False,  # Should be converted to bool
+                "positionsnummerhv": 0,  # Should be converted to int
+                "arSpelandeLedare": False,  # Should be converted to bool
+                "ansvarig": False,  # Should be converted to bool
+            },
+        )
+
+    def test_save_match_participant_verification_failure(self):
+        """Unit test for save_match_participant method with verification failure."""
+        # Mock the _api_request method with a roster response where values don't match
+        mock_response = {
+            "spelare": [
+                {
+                    "matchdeltagareid": 46123762,
+                    "fornamn": "John",
+                    "efternamn": "Doe",
+                    "trojnummer": 7,  # Different from what we requested (92)
+                    "lagkapten": False,
+                    "ersattare": False,
+                }
+            ]
+        }
+        self.client._api_request = MagicMock(return_value=mock_response)
+
+        # Call save_match_participant
+        participant_data = {
+            "matchdeltagareid": "46123762",
+            "trojnummer": "92",
+            "lagdelid": "0",
+            "lagkapten": "false",
+            "ersattare": "false",
+            "positionsnummerhv": "0",
+            "arSpelandeLedare": "false",
+            "ansvarig": "false",
+        }
+        response = self.client.save_match_participant(participant_data)
+
+        # Verify the result structure
+        self.assertTrue(response["success"])  # API call succeeded
+        self.assertFalse(response["verified"])  # But verification failed
+        self.assertEqual(response["roster"], mock_response)
+        self.assertEqual(response["updated_player"]["matchdeltagareid"], 46123762)
+        self.assertEqual(response["updated_player"]["trojnummer"], 7)  # Not what we requested
+
+        # Verify the API call
+        self.client._api_request.assert_called_once_with(
+            f"{FogisApiClient.BASE_URL}/MatchWebMetoder.aspx/SparaMatchdeltagare",
+            {
+                "matchdeltagareid": 46123762,
+                "trojnummer": 92,
+                "lagdelid": 0,
+                "lagkapten": False,
+                "ersattare": False,
+                "positionsnummerhv": 0,
+                "arSpelandeLedare": False,
+                "ansvarig": False,
+            },
+        )
+
+    def test_save_match_participant_spelareid_fallback(self):
+        """Unit test for save_match_participant method with spelareid instead of matchdeltagareid."""
+        # Mock the _api_request method with a roster response that uses spelareid instead of matchdeltagareid
+        mock_response = {
+            "spelare": [
+                {
+                    "spelareid": 12345,  # Different ID field (spelareid instead of matchdeltagareid)
+                    "fornamn": "John",
+                    "efternamn": "Doe",
+                    "trojnummer": 92,  # Same jersey number as requested
+                    "lagkapten": False,
+                    "ersattare": False,
+                }
+            ]
+        }
+        self.client._api_request = MagicMock(return_value=mock_response)
+
+        # Call save_match_participant
+        participant_data = {
+            "matchdeltagareid": "46123762",  # This ID won't be found in the response
+            "trojnummer": "92",  # But this jersey number will match
+            "lagdelid": "0",
+            "lagkapten": "false",
+            "ersattare": "false",
+            "positionsnummerhv": "0",
+            "arSpelandeLedare": "false",
+            "ansvarig": "false",
+        }
+        response = self.client.save_match_participant(participant_data)
+
+        # Verify the result structure
+        self.assertTrue(response["success"])  # API call succeeded
+        self.assertTrue(response["verified"])  # Verification should succeed based on jersey number
+        self.assertEqual(response["roster"], mock_response)
+        self.assertEqual(response["updated_player"]["trojnummer"], 92)  # Jersey number matches
+
+        # Verify the API call
+        self.client._api_request.assert_called_once_with(
+            f"{FogisApiClient.BASE_URL}/MatchWebMetoder.aspx/SparaMatchdeltagare",
+            {
+                "matchdeltagareid": 46123762,
+                "trojnummer": 92,
+                "lagdelid": 0,
+                "lagkapten": False,
+                "ersattare": False,
+                "positionsnummerhv": 0,
+                "arSpelandeLedare": False,
+                "ansvarig": False,
             },
         )
 


### PR DESCRIPTION
## Description

This PR implements the `save_match_participant` method in the `FogisApiClient` class, which allows users to update player information such as jersey numbers and captain status in the FOGIS system.

## Features

- Added a new `MatchParticipantDict` type definition in `types.py`
- Implemented the `save_match_participant` method with robust verification
- Added clear documentation about the distinction between `matchdeltagareid` and `spelareid`
- Added unit tests and integration tests
- Updated the mock server to support the new endpoint

## Usage Example

```python
from fogis_api_client import FogisApiClient

# Initialize the client
client = FogisApiClient(username="your_username", password="your_password")

# Update a player's jersey number and set as captain
participant = {
    "matchdeltagareid": 46123762,  # Match-specific ID
    "trojnummer": 10,              # Jersey number
    "lagdelid": 0,                 # Team part ID (typically 0)
    "lagkapten": True,             # Set as team captain
    "ersattare": False,            # Not a substitute
    "positionsnummerhv": 0,        # Position number (typically 0)
    "arSpelandeLedare": False,     # Not a playing leader
    "ansvarig": False              # Not responsible
}

# Save the updated participant information
response = client.save_match_participant(participant)

# Check if the update was successful and verified
if response["success"] and response["verified"]:
    print(f"Successfully updated player with ID {participant['matchdeltagareid']}")
    print(f"New jersey number: {response['updated_player']['trojnummer']}")
else:
    print("Update failed or changes not verified")
```

Fixes #3
