### PR TITLE
Hotfix: Fix Match Result Reporting Functionality

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.4.1] - 2025-05-15
+
+### Fixed
+- Fixed match result reporting functionality to handle both flat and nested data structures (Issue #141)
+- Added backward compatibility for the `report_match_result` method
+- Improved documentation for API data structures
+- Added tests to verify correct API communication
+
 ## [0.3.1] - 2025-04-25
 
 ### Fixed

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="fogis-api-client-timmyBird",
-    version="0.4.0",
+    version="0.4.1",
     author="Bartek Svaberg",
     author_email="bartek.svaberg@gmail.com",
     description="A Python client for the FOGIS API (Svensk Fotboll)",

--- a/tests/test_fogis_api_client.py
+++ b/tests/test_fogis_api_client.py
@@ -427,15 +427,30 @@ class TestFogisApiClient(unittest.TestCase):
         # Verify the result
         self.assertEqual(response, {"success": True})
 
-        # Verify the API call
+        # Verify the API call - now using the nested structure
         self.client._api_request.assert_called_once_with(
             f"{FogisApiClient.BASE_URL}/MatchWebMetoder.aspx/SparaMatchresultatLista",
             {
-                "matchid": 12345,  # Should be converted to int
-                "hemmamal": 2,
-                "bortamal": 1,
-                "halvtidHemmamal": 1,
-                "halvtidBortamal": 0,
+                "matchresultatListaJSON": [
+                    {
+                        "matchid": 12345,  # Should be converted to int
+                        "matchresultattypid": 1,  # Full time
+                        "matchlag1mal": 2,
+                        "matchlag2mal": 1,
+                        "wo": False,
+                        "ow": False,
+                        "ww": False
+                    },
+                    {
+                        "matchid": 12345,
+                        "matchresultattypid": 2,  # Half-time
+                        "matchlag1mal": 1,
+                        "matchlag2mal": 0,
+                        "wo": False,
+                        "ow": False,
+                        "ww": False
+                    }
+                ]
             },
         )
 
@@ -453,14 +468,31 @@ class TestFogisApiClient(unittest.TestCase):
         # Verify the exception message
         self.assertIn("API request failed", str(excinfo.exception))
 
-        # Verify the API call
+        # Verify the API call - now using the nested structure
         self.client._api_request.assert_called_once_with(
             f"{FogisApiClient.BASE_URL}/MatchWebMetoder.aspx/SparaMatchresultatLista",
             {
-                "matchid": 12345,
-                "hemmamal": 2,
-                "bortamal": 1,
-            },  # Should be converted to int
+                "matchresultatListaJSON": [
+                    {
+                        "matchid": 12345,  # Should be converted to int
+                        "matchresultattypid": 1,  # Full time
+                        "matchlag1mal": 2,
+                        "matchlag2mal": 1,
+                        "wo": False,
+                        "ow": False,
+                        "ww": False
+                    },
+                    {
+                        "matchid": 12345,
+                        "matchresultattypid": 2,  # Half-time
+                        "matchlag1mal": 0,
+                        "matchlag2mal": 0,
+                        "wo": False,
+                        "ow": False,
+                        "ww": False
+                    }
+                ]
+            },
         )
 
     def test_event_types_dictionary(self):

--- a/tests/test_match_result_formats.py
+++ b/tests/test_match_result_formats.py
@@ -1,0 +1,135 @@
+import unittest
+from unittest.mock import MagicMock
+
+from fogis_api_client.fogis_api_client import FogisApiClient
+
+
+class TestMatchResultFormats(unittest.TestCase):
+    """Test case for verifying both match result formats work."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.client = FogisApiClient(username="test", password="test")
+        self.client._api_request = MagicMock(return_value={"success": True})
+
+    def test_flat_format(self):
+        """Test that the flat format works correctly."""
+        # Flat format (new style)
+        flat_result_data = {
+            "matchid": 12345,
+            "hemmamal": 2,
+            "bortamal": 1,
+            "halvtidHemmamal": 1,
+            "halvtidBortamal": 0,
+        }
+        
+        response = self.client.report_match_result(flat_result_data)
+        
+        # Verify the result
+        self.assertEqual(response, {"success": True})
+        
+        # Verify the API was called with the correct nested structure
+        expected_payload = {
+            "matchresultatListaJSON": [
+                {
+                    "matchid": 12345,
+                    "matchresultattypid": 1,  # Full time
+                    "matchlag1mal": 2,
+                    "matchlag2mal": 1,
+                    "wo": False,
+                    "ow": False,
+                    "ww": False
+                },
+                {
+                    "matchid": 12345,
+                    "matchresultattypid": 2,  # Half-time
+                    "matchlag1mal": 1,
+                    "matchlag2mal": 0,
+                    "wo": False,
+                    "ow": False,
+                    "ww": False
+                }
+            ]
+        }
+        
+        self.client._api_request.assert_called_once()
+        call_args = self.client._api_request.call_args[0]
+        self.assertEqual(call_args[0], f"{FogisApiClient.BASE_URL}/MatchWebMetoder.aspx/SparaMatchresultatLista")
+        
+        # Check that the structure matches what we expect
+        actual_payload = call_args[1]
+        self.assertIn("matchresultatListaJSON", actual_payload)
+        self.assertEqual(len(actual_payload["matchresultatListaJSON"]), 2)
+        
+        # Check full-time result
+        fulltime = actual_payload["matchresultatListaJSON"][0]
+        self.assertEqual(fulltime["matchid"], 12345)
+        self.assertEqual(fulltime["matchresultattypid"], 1)
+        self.assertEqual(fulltime["matchlag1mal"], 2)
+        self.assertEqual(fulltime["matchlag2mal"], 1)
+        
+        # Check half-time result
+        halftime = actual_payload["matchresultatListaJSON"][1]
+        self.assertEqual(halftime["matchid"], 12345)
+        self.assertEqual(halftime["matchresultattypid"], 2)
+        self.assertEqual(halftime["matchlag1mal"], 1)
+        self.assertEqual(halftime["matchlag2mal"], 0)
+
+    def test_nested_format(self):
+        """Test that the nested format works correctly."""
+        # Nested format (old style from v0.0.5)
+        nested_result_data = {
+            "matchresultatListaJSON": [
+                {
+                    "matchid": 12345,
+                    "matchresultattypid": 1,  # Full time
+                    "matchlag1mal": 2,
+                    "matchlag2mal": 1,
+                    "wo": False,
+                    "ow": False,
+                    "ww": False
+                },
+                {
+                    "matchid": 12345,
+                    "matchresultattypid": 2,  # Half-time
+                    "matchlag1mal": 1,
+                    "matchlag2mal": 0,
+                    "wo": False,
+                    "ow": False,
+                    "ww": False
+                }
+            ]
+        }
+        
+        response = self.client.report_match_result(nested_result_data)
+        
+        # Verify the result
+        self.assertEqual(response, {"success": True})
+        
+        # Verify the API was called with the correct nested structure (should be unchanged)
+        self.client._api_request.assert_called_once()
+        call_args = self.client._api_request.call_args[0]
+        self.assertEqual(call_args[0], f"{FogisApiClient.BASE_URL}/MatchWebMetoder.aspx/SparaMatchresultatLista")
+        
+        # Check that the structure matches what we expect
+        actual_payload = call_args[1]
+        self.assertIn("matchresultatListaJSON", actual_payload)
+        self.assertEqual(len(actual_payload["matchresultatListaJSON"]), 2)
+        
+        # Check full-time result
+        fulltime = actual_payload["matchresultatListaJSON"][0]
+        self.assertEqual(fulltime["matchid"], 12345)
+        self.assertEqual(fulltime["matchresultattypid"], 1)
+        self.assertEqual(fulltime["matchlag1mal"], 2)
+        self.assertEqual(fulltime["matchlag2mal"], 1)
+        
+        # Check half-time result
+        halftime = actual_payload["matchresultatListaJSON"][1]
+        self.assertEqual(halftime["matchid"], 12345)
+        self.assertEqual(halftime["matchresultattypid"], 2)
+        self.assertEqual(halftime["matchlag1mal"], 1)
+        self.assertEqual(halftime["matchlag2mal"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Hotfix: Fix Match Result Reporting Functionality

## Description
This PR fixes the match result reporting functionality that was broken due to a mismatch between the data structure expected by the API client and what the FOGIS API requires.

## Changes
- Modified `report_match_result` method to accept both flat and nested data structures
- Added conversion from flat structure to nested structure before sending to the API
- Enhanced documentation to clearly explain API requirements
- Added tests to verify correct API communication
- Updated version to 0.4.1
- Updated changelog

## Related Issue
Fixes #141

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing
- Added comprehensive tests for both flat and nested data structures
- Verified that both formats work correctly
- Ensured backward compatibility with existing code

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules