### PR TITLE
Add workflow to sync CONTRIBUTING.md from central repository

### DIFF
--- a/.github/workflows/contributing-sync.yml
+++ b/.github/workflows/contributing-sync.yml
@@ -1,0 +1,41 @@
+name: Sync CONTRIBUTING.md
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'  # Run every Sunday at midnight
+
+jobs:
+  sync-contributing:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        
+      - name: Get source CONTRIBUTING.md
+        run: |
+          # Download source CONTRIBUTING.md
+          curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3.raw" \
+            "https://api.github.com/repos/PitchConnect/contribution-guidelines/contents/CONTRIBUTING.md" > source_contributing.md
+          
+          # Check if target CONTRIBUTING.md exists
+          if [ -f "CONTRIBUTING.md" ]; then
+            # Extract repository-specific section
+            REPO_SPECIFIC=$(sed -n "/^## Repository-Specific Guidelines/,/<!-- END COMMON SECTION -->/p" "CONTRIBUTING.md" || echo "## Repository-Specific Guidelines\n\n<!-- Add repository-specific guidelines here -->\n\n<!-- END COMMON SECTION -->")
+            
+            # Replace repository-specific section in source file
+            sed -i "/^## Repository-Specific Guidelines/,/<!-- END COMMON SECTION -->/c\\$REPO_SPECIFIC" source_contributing.md
+          fi
+          
+          # Update target CONTRIBUTING.md
+          mv source_contributing.md "CONTRIBUTING.md"
+          
+          # Commit changes if any
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git add "CONTRIBUTING.md"
+          git diff --staged --quiet || git commit -m "Update CONTRIBUTING.md from contribution-guidelines"
+          git push


### PR DESCRIPTION
# Add Workflow to Sync CONTRIBUTING.md from Central Repository

This PR adds a workflow that automatically syncs the CONTRIBUTING.md file from the central contribution-guidelines repository while preserving any repository-specific guidelines.

## Changes

Added a new workflow file `.github/workflows/contributing-sync.yml` that:

1. Runs on manual trigger or weekly schedule (every Sunday at midnight)
2. Downloads the latest CONTRIBUTING.md from the contribution-guidelines repository
3. Preserves the "Repository-Specific Guidelines" section from the local CONTRIBUTING.md
4. Updates the local CONTRIBUTING.md with the latest content
5. Commits and pushes the changes if any

## Benefits

1. **Consistency**: Ensures that all repositories have the same contribution guidelines
2. **Reduced Maintenance**: No need to manually update CONTRIBUTING.md in each repository
3. **Flexibility**: Preserves repository-specific guidelines while keeping common sections in sync
4. **Automation**: Runs automatically on a schedule or can be manually triggered

## Related Changes

This workflow will ensure that the standardized label system and other updates to the central CONTRIBUTING.md file are automatically propagated to this repository.

## Testing

The workflow can be manually triggered after merging to test its functionality.
