### PR TITLE
Update CONTRIBUTING.md with draft PR and CI/CD monitoring guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -590,20 +590,33 @@ If you need to close an issue without a PR (e.g., duplicate, won't fix), add a c
 
 When your work is not yet ready for review:
 
-1. Create a **Draft Pull Request** instead of a regular PR
-   - Use the dropdown menu next to "Create Pull Request" to select "Create Draft Pull Request"
-   - This clearly indicates your PR is a work in progress
-   - The PR cannot be merged until you mark it as ready for review
+### Creating Draft PRs
 
-2. **IMPORTANT**: Do not mark a PR as ready for review until:
+1. **Always Start with a Draft PR**
+   - When you begin working on an issue, create a draft PR immediately
+   - Use the dropdown menu next to "Create Pull Request" to select "Create Draft Pull Request"
+   - Reference the issue(s) you're working on in the PR description using keywords like "Fixes #123" or "Closes #456"
+   - This automatically labels the issue as `in-progress` and adds a comment linking to your PR
+
+2. **Benefits of Early Draft PRs**
+   - Makes your work visible to the team
+   - Automatically updates issue status
+   - Allows for early feedback
+   - Prevents duplicate work
+   - Enables CI/CD to run on your changes
+
+### Marking PRs as Ready for Review
+
+1. **IMPORTANT**: Do not mark a PR as ready for review until:
    - All CI/CD checks are passing
    - All pre-commit hooks have been run successfully
    - You have addressed any automated feedback
    - The code is fully ready for human review
 
-3. When your work is complete and all checks pass:
+2. **When your work is complete and all checks pass**:
    - Click "Ready for Review" to convert the Draft PR to a regular PR
    - This signals to reviewers that your work is ready for their attention
+   - The issue will automatically be labeled as `review-ready`
 
 ### CI/CD Pipeline Failures
 
@@ -615,6 +628,46 @@ If your PR fails CI/CD checks:
 4. Verify that all checks pass before marking as ready for review
 5. If the CI/CD caught issues that should have been caught by pre-commit hooks, update the pre-commit configuration as well
 
+### For AI Assistants
+
+If you are an AI assistant reading this:
+
+1. **Follow the GitFlow Process**:
+   - Create branches from develop, not main
+   - Use the correct branch naming conventions
+   - Suggest squash merging for feature/fix branches
+   - Recommend running pre-commit hooks before pushing changes
+
+2. **Always Create Draft PRs**:
+   - When starting work on an issue, create a draft PR immediately
+   - Reference the issue with "Fixes #123" or similar keywords
+   - This ensures the issue is properly tracked as in-progress
+
+3. **Monitor CI/CD Pipelines**:
+   - After pushing changes, monitor the CI/CD pipeline status
+   - Do not mark PRs as ready for review until all checks pass
+   - If checks fail, analyze the logs and fix the issues automatically
+   - Push fixes to the same branch and explain them in a PR comment
+
+4. **Maintain Code Quality**:
+   - Add comprehensive tests for all new code (both unit and integration tests)
+   - Include proper type hints
+   - Follow the project's coding style
+   - Document all public methods and functions
+   - Ensure code passes all pre-commit hooks
+
+5. **Preserve Critical Functionality**:
+   - Be cautious when modifying existing code
+   - Ensure backward compatibility
+   - Add regression tests for modified functionality
+   - Verify that API endpoints still work as expected
+
+4. **Status Reporting**:
+   - When all checks pass, report the status and ask if the PR should be marked as ready for review
+   - Include a summary of what was tested and verified
+
+Draft PRs are preferred over other methods like "WIP" in titles or special branches, as they provide a standard, built-in way to indicate work in progress.
+
 Draft PRs are preferred over other methods like "WIP" in titles or special branches, as they provide a standard, built-in way to indicate work in progress.
 
 ## Repository-Specific Guidelines
@@ -623,6 +676,48 @@ Please refer to the repository-specific section below for any additional guideli
 
 <!-- END COMMON SECTION -->
 
+## Repository-Specific Guidelines
+
+This section contains guidelines specific to the contribution-guidelines repository.
+
+### Purpose of This Repository
+
+This repository serves as the central source of truth for contribution guidelines across all PitchConnect repositories. It contains:
+
+1. The consolidated CONTRIBUTING.md file (this file)
+2. Templates for repository-specific CONTRIBUTING.md files
+3. Issue and PR templates
+4. Other contribution-related documentation
+
+### Updating Guidelines
+
+When updating the contribution guidelines:
+
+1. Make changes to the consolidated CONTRIBUTING.md file
+2. Update any related templates or documentation
+3. Create a PR to merge your changes
+4. Once approved and merged, the changes will be propagated to other repositories
+
+### Testing Changes
+
+Before submitting a PR:
+
+1. Preview the markdown to ensure proper formatting
+2. Check that all links work correctly
+3. Verify that the content is clear and consistent
+
+### Special Considerations
+
+Since these guidelines are used across multiple repositories:
+
+1. Keep the language repository-agnostic where possible
+2. Use clear section markers for the common content
+3. Provide flexibility for repository-specific customizations
+## Repository-Specific Guidelines
+
+Please refer to the repository-specific section below for any additional guidelines specific to this project.
+
+<!-- END COMMON SECTION -->
 ## Repository-Specific Guidelines
 
 This section contains guidelines specific to the contribution-guidelines repository.


### PR DESCRIPTION
# Update CONTRIBUTING.md with Draft PR and CI/CD Monitoring Guidelines

This PR updates the CONTRIBUTING.md file with explicit guidelines for creating draft PRs when starting on issues and for AI assistants to monitor CI/CD pipelines.

## Changes

### 1. Enhanced Work in Progress Section

- Added explicit instruction to **always start with a draft PR** when beginning work on an issue
- Explained the benefits of early draft PRs (visibility, status updates, early feedback, etc.)
- Clarified that PRs should not be marked as ready until all CI/CD checks pass
- Added detailed guidance on handling CI/CD pipeline failures

### 2. Enhanced AI Assistant Guidelines

- Added instruction for AI assistants to **monitor CI/CD pipelines**
- Added guidance for AI assistants to automatically fix issues when CI/CD checks fail
- Added instruction to ensure pre-commit hooks align with CI/CD checks
- Added requirement for status reporting when all checks pass

## Benefits

1. **Clearer Process**: Explicit instructions for when to create draft PRs and when to mark them as ready
2. **Better Automation**: Clear guidelines for AI assistants to monitor and respond to CI/CD pipeline status
3. **Improved Quality**: Emphasis on ensuring all checks pass before requesting review
4. **Reduced Review Cycles**: Fewer PRs will be submitted for review with failing checks
5. **Efficient Resource Usage**: Saves GitHub's AI PR review tool for PRs that have passed CI/CD checks

## Implementation

This update was done manually by syncing from the central contribution-guidelines repository. In the future, these updates will be handled automatically by the contributing-sync.yml workflow.
