### PR TITLE
Fixes #136: Reduce code duplication in integration tests

### DIFF
--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -148,6 +148,33 @@ To add new tests, follow these steps:
 
 ### Test Structure
 
+Each test should use the `mock_api_urls` fixture to handle API URL overrides. This fixture temporarily overrides the API URLs to point to the mock server and restores them after the test completes. It also clears the request history at the beginning of each test for better isolation.
+
+Example test structure:
+
+```python
+def test_some_functionality(self, mock_fogis_server, test_credentials, mock_api_urls):
+    """Test some functionality."""
+    # Create a client with test credentials
+    client = FogisApiClient(
+        username=test_credentials["username"],
+        password=test_credentials["password"],
+    )
+
+    # Test the functionality
+    result = client.some_method()
+
+    # Verify the result
+    assert result is not None
+```
+
+The `mock_api_urls` fixture handles:
+1. Storing the original base URLs
+2. Overriding the base URLs to use the mock server
+3. Clearing request history for better test isolation
+4. Restoring the original URLs after the test completes, even if the test fails
+
+
 Integration tests should follow this structure:
 
 1. **Setup**: Configure the client to use the mock server

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -10,12 +10,12 @@ from typing import Dict, Generator
 import pytest
 import requests
 
+# Import the API clients
+from fogis_api_client.public_api_client import FogisApiClient
+from fogis_api_client.internal.api_client import InternalApiClient
+
 # Import the mock server
 from integration_tests.mock_fogis_server import MockFogisServer
-
-# Import the API clients
-from fogis_api_client.fogis_api_client import FogisApiClient
-from fogis_api_client.internal.api_client import InternalApiClient
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -11,7 +11,7 @@ import pytest
 import requests
 
 # Import the API clients
-from fogis_api_client.public_api_client import FogisApiClient
+from fogis_api_client import FogisApiClient
 from fogis_api_client.internal.api_client import InternalApiClient
 
 # Import the mock server

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -13,6 +13,10 @@ import requests
 # Import the mock server
 from integration_tests.mock_fogis_server import MockFogisServer
 
+# Import the API clients
+from fogis_api_client.fogis_api_client import FogisApiClient
+from fogis_api_client.internal.api_client import InternalApiClient
+
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -123,3 +127,41 @@ def test_credentials() -> Dict[str, str]:
         "username": "test_user",
         "password": "test_password",
     }
+
+
+@pytest.fixture
+def mock_api_urls(mock_fogis_server: Dict[str, str]) -> None:
+    """
+    Temporarily override API URLs to point to mock server.
+
+    This fixture handles setting up and tearing down the API URLs for tests.
+    It ensures that the URLs are properly restored after the test completes,
+    even if the test fails.
+
+    Args:
+        mock_fogis_server: The mock server fixture
+
+    Yields:
+        None
+    """
+    # Store original base URLs
+    original_base_url = FogisApiClient.BASE_URL
+    original_internal_base_url = InternalApiClient.BASE_URL
+
+    # Override base URLs to use the mock server
+    FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
+    InternalApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
+
+    # Clear request history at the beginning of each test for better isolation
+    try:
+        requests.get(f"{mock_fogis_server['base_url']}/clear-request-history")
+    except requests.exceptions.RequestException as e:
+        logger.warning(f"Failed to clear request history: {e}")
+
+    try:
+        # Yield control to the test
+        yield
+    finally:
+        # Restore original URLs, even if the test fails
+        FogisApiClient.BASE_URL = original_base_url
+        InternalApiClient.BASE_URL = original_internal_base_url

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -154,7 +154,7 @@ def mock_api_urls(mock_fogis_server: Dict[str, str]) -> None:
 
     # Clear request history at the beginning of each test for better isolation
     try:
-        requests.get(f"{mock_fogis_server['base_url']}/clear-request-history")
+        requests.post(f"{mock_fogis_server['base_url']}/clear-request-history")
     except requests.exceptions.RequestException as e:
         logger.warning(f"Failed to clear request history: {e}")
 

--- a/integration_tests/test_match_result_reporting.py
+++ b/integration_tests/test_match_result_reporting.py
@@ -21,16 +21,8 @@ logger = logging.getLogger(__name__)
 class TestMatchResultReporting:
     """Integration tests for match result reporting."""
 
-    def test_report_match_result_flat_format(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
+    def test_report_match_result_flat_format(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test reporting match results using the flat format."""
-        # Override the base URL to use the mock server
-        original_base_url = FogisApiClient.BASE_URL
-        FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
-
-        # Also override the internal API client's base URL
-        from fogis_api_client.internal.api_client import InternalApiClient
-        original_internal_base_url = InternalApiClient.BASE_URL
-        InternalApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
 
         # Create a client with test credentials
         client = FogisApiClient(
@@ -113,20 +105,10 @@ class TestMatchResultReporting:
         assert "success" in response
         assert response["success"] is True
 
-        # Restore the original base URLs
-        FogisApiClient.BASE_URL = original_base_url
-        InternalApiClient.BASE_URL = original_internal_base_url
 
-    def test_report_match_result_missing_fields(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
+
+    def test_report_match_result_missing_fields(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test reporting match results with missing fields."""
-        # Override the base URL to use the mock server
-        original_base_url = FogisApiClient.BASE_URL
-        FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
-
-        # Also override the internal API client's base URL
-        from fogis_api_client.internal.api_client import InternalApiClient
-        original_internal_base_url = InternalApiClient.BASE_URL
-        InternalApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
 
         # Create a client with test credentials
         client = FogisApiClient(
@@ -184,20 +166,10 @@ class TestMatchResultReporting:
         with pytest.raises(FogisAPIRequestError):
             client.report_match_result(result_data)
 
-        # Restore the original base URLs
-        FogisApiClient.BASE_URL = original_base_url
-        InternalApiClient.BASE_URL = original_internal_base_url
 
-    def test_report_match_result_with_extra_time(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
+
+    def test_report_match_result_with_extra_time(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test reporting match results with extra time."""
-        # Override the base URL to use the mock server
-        original_base_url = FogisApiClient.BASE_URL
-        FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
-
-        # Also override the internal API client's base URL
-        from fogis_api_client.internal.api_client import InternalApiClient
-        original_internal_base_url = InternalApiClient.BASE_URL
-        InternalApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
 
         # Create a client with test credentials
         client = FogisApiClient(
@@ -272,20 +244,10 @@ class TestMatchResultReporting:
         assert "success" in response
         assert response["success"] is True
 
-        # Restore the original base URLs
-        FogisApiClient.BASE_URL = original_base_url
-        InternalApiClient.BASE_URL = original_internal_base_url
 
-    def test_report_match_result_walkover(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
+
+    def test_report_match_result_walkover(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test reporting match results with walkover."""
-        # Override the base URL to use the mock server
-        original_base_url = FogisApiClient.BASE_URL
-        FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
-
-        # Also override the internal API client's base URL
-        from fogis_api_client.internal.api_client import InternalApiClient
-        original_internal_base_url = InternalApiClient.BASE_URL
-        InternalApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
 
         # Create a client with test credentials
         client = FogisApiClient(
@@ -392,22 +354,12 @@ class TestMatchResultReporting:
         assert half_time["matchlag1mal"] == 1
         assert half_time["matchlag2mal"] == 0
 
-        # Restore the original base URLs
-        FogisApiClient.BASE_URL = original_base_url
-        InternalApiClient.BASE_URL = original_internal_base_url
+
 
     def test_verify_request_structure_with_extra_time_and_penalties(
-        self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]
+        self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls
     ):
         """Test that verifies the structure of requests with extra time and penalties."""
-        # Override the base URL to use the mock server
-        original_base_url = FogisApiClient.BASE_URL
-        FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
-
-        # Also override the internal API client's base URL
-        from fogis_api_client.internal.api_client import InternalApiClient
-        original_internal_base_url = InternalApiClient.BASE_URL
-        InternalApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
 
         # Create a client with test credentials
         client = FogisApiClient(
@@ -473,6 +425,3 @@ class TestMatchResultReporting:
         # Note: Extra time and penalties are not sent as separate result types in the API
         # They are only included in the flat format, but the API only supports result types 1 and 2
 
-        # Restore the original base URLs
-        FogisApiClient.BASE_URL = original_base_url
-        InternalApiClient.BASE_URL = original_internal_base_url

--- a/integration_tests/test_match_result_reporting.py
+++ b/integration_tests/test_match_result_reporting.py
@@ -21,7 +21,9 @@ logger = logging.getLogger(__name__)
 class TestMatchResultReporting:
     """Integration tests for match result reporting."""
 
-    def test_report_match_result_flat_format(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
+    def test_report_match_result_flat_format(
+        self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls
+    ):
         """Test reporting match results using the flat format."""
 
         # Create a client with test credentials
@@ -51,20 +53,10 @@ class TestMatchResultReporting:
         assert "success" in response
         assert response["success"] is True
 
-        # Restore the original base URLs
-        FogisApiClient.BASE_URL = original_base_url
-        InternalApiClient.BASE_URL = original_internal_base_url
+        # No need to restore base URLs - the fixture will handle that
 
-    def test_report_match_result_nested_format(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
+    def test_report_match_result_nested_format(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test reporting match results using the nested format."""
-        # Override the base URL to use the mock server
-        original_base_url = FogisApiClient.BASE_URL
-        FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
-
-        # Also override the internal API client's base URL
-        from fogis_api_client.internal.api_client import InternalApiClient
-        original_internal_base_url = InternalApiClient.BASE_URL
-        InternalApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
 
         # Create a client with test credentials
         client = FogisApiClient(
@@ -105,9 +97,9 @@ class TestMatchResultReporting:
         assert "success" in response
         assert response["success"] is True
 
-
-
-    def test_report_match_result_missing_fields(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
+    def test_report_match_result_missing_fields(
+        self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls
+    ):
         """Test reporting match results with missing fields."""
 
         # Create a client with test credentials
@@ -126,22 +118,12 @@ class TestMatchResultReporting:
         with pytest.raises(ValueError):
             client.report_match_result(result_data)
 
-        # Restore the original base URLs
-        FogisApiClient.BASE_URL = original_base_url
-        InternalApiClient.BASE_URL = original_internal_base_url
+        # No need to restore base URLs - the fixture will handle that
 
     def test_report_match_result_invalid_nested_format(
-        self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]
+        self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls
     ):
         """Test reporting match results with invalid nested format."""
-        # Override the base URL to use the mock server
-        original_base_url = FogisApiClient.BASE_URL
-        FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
-
-        # Also override the internal API client's base URL
-        from fogis_api_client.internal.api_client import InternalApiClient
-        original_internal_base_url = InternalApiClient.BASE_URL
-        InternalApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
 
         # Create a client with test credentials
         client = FogisApiClient(
@@ -166,9 +148,9 @@ class TestMatchResultReporting:
         with pytest.raises(FogisAPIRequestError):
             client.report_match_result(result_data)
 
-
-
-    def test_report_match_result_with_extra_time(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
+    def test_report_match_result_with_extra_time(
+        self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls
+    ):
         """Test reporting match results with extra time."""
 
         # Create a client with test credentials
@@ -199,20 +181,10 @@ class TestMatchResultReporting:
         assert "success" in response
         assert response["success"] is True
 
-        # Restore the original base URLs
-        FogisApiClient.BASE_URL = original_base_url
-        InternalApiClient.BASE_URL = original_internal_base_url
+        # No need to restore base URLs - the fixture will handle that
 
-    def test_report_match_result_with_penalties(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
+    def test_report_match_result_with_penalties(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test reporting match results with penalties."""
-        # Override the base URL to use the mock server
-        original_base_url = FogisApiClient.BASE_URL
-        FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
-
-        # Also override the internal API client's base URL
-        from fogis_api_client.internal.api_client import InternalApiClient
-        original_internal_base_url = InternalApiClient.BASE_URL
-        InternalApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
 
         # Create a client with test credentials
         client = FogisApiClient(
@@ -244,9 +216,9 @@ class TestMatchResultReporting:
         assert "success" in response
         assert response["success"] is True
 
-
-
-    def test_report_match_result_walkover(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
+    def test_report_match_result_walkover(
+        self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls
+    ):
         """Test reporting match results with walkover."""
 
         # Create a client with test credentials
@@ -279,20 +251,10 @@ class TestMatchResultReporting:
         assert "success" in response
         assert response["success"] is True
 
-        # Restore the original base URLs
-        FogisApiClient.BASE_URL = original_base_url
-        InternalApiClient.BASE_URL = original_internal_base_url
+        # No need to restore base URLs - the fixture will handle that
 
-    def test_complete_match_reporting_workflow(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
+    def test_complete_match_reporting_workflow(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test the complete match reporting workflow."""
-        # Override the base URL to use the mock server
-        original_base_url = FogisApiClient.BASE_URL
-        FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
-
-        # Also override the internal API client's base URL
-        from fogis_api_client.internal.api_client import InternalApiClient
-        original_internal_base_url = InternalApiClient.BASE_URL
-        InternalApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
 
         # Create a client with test credentials
         client = FogisApiClient(
@@ -353,8 +315,6 @@ class TestMatchResultReporting:
         assert half_time["matchid"] == match_id
         assert half_time["matchlag1mal"] == 1
         assert half_time["matchlag2mal"] == 0
-
-
 
     def test_verify_request_structure_with_extra_time_and_penalties(
         self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls
@@ -424,4 +384,3 @@ class TestMatchResultReporting:
 
         # Note: Extra time and penalties are not sent as separate result types in the API
         # They are only included in the flat format, but the API only supports result types 1 and 2
-

--- a/integration_tests/test_with_mock_server.py
+++ b/integration_tests/test_with_mock_server.py
@@ -97,8 +97,6 @@ class TestFogisApiClientWithMockServer:
         assert "datum" in match
         assert "tid" in match
 
-
-
     def test_fetch_match_details(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test fetching match details."""
 
@@ -119,8 +117,6 @@ class TestFogisApiClientWithMockServer:
         assert "bortalag" in match
         assert "datum" in match
         assert "tid" in match
-
-
 
     def test_fetch_match_players(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test fetching match players."""
@@ -153,8 +149,6 @@ class TestFogisApiClientWithMockServer:
         assert "trojnummer" in home_player
         assert "fornamn" in home_player
         assert "efternamn" in home_player
-
-
 
     def test_fetch_match_officials(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test fetching match officials."""
@@ -189,8 +183,6 @@ class TestFogisApiClientWithMockServer:
         assert "fornamn" in home_official
         assert "efternamn" in home_official
 
-
-
     def test_fetch_match_events(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test fetching match events."""
 
@@ -217,14 +209,8 @@ class TestFogisApiClientWithMockServer:
         assert "matchminut" in event  # New field name instead of minut
         assert "matchlagid" in event  # New field name instead of lagid
 
-
-
     def test_fetch_match_result(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test fetching match result."""
-
-        original_internal_base_url = InternalApiClient.BASE_URL
-
-        InternalApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
 
         # Create a client with test credentials
         client = FogisApiClient(
@@ -249,8 +235,6 @@ class TestFogisApiClientWithMockServer:
             assert "matchid" in result[0]
             assert "matchlag1mal" in result[0]
             assert "matchlag2mal" in result[0]
-
-
 
     def test_report_match_result(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test reporting match results."""
@@ -282,11 +266,7 @@ class TestFogisApiClientWithMockServer:
         assert "success" in response
         assert response["success"] is True
 
-        # Restore the original base URLs
-
-        FogisApiClient.BASE_URL = original_base_url
-
-        InternalApiClient.BASE_URL = original_internal_base_url
+        # No need to restore base URLs - the fixture will handle that
 
     def test_report_match_event(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test reporting a match event."""
@@ -322,12 +302,8 @@ class TestFogisApiClientWithMockServer:
         with pytest.raises(FogisAPIRequestError):
             client.report_match_event(event_data)
 
-
-
     def test_clear_match_events(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test clearing match events."""
-
-
 
         # Create a client with test credentials
         client = FogisApiClient(
@@ -343,8 +319,6 @@ class TestFogisApiClientWithMockServer:
         assert isinstance(response, dict)
         assert "success" in response
         assert response["success"] is True
-
-
 
     def test_mark_reporting_finished(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test marking reporting as finished."""
@@ -364,11 +338,7 @@ class TestFogisApiClientWithMockServer:
         assert "success" in response
         assert response["success"] is True
 
-        # Restore the original base URLs
-
-        FogisApiClient.BASE_URL = original_base_url
-
-        InternalApiClient.BASE_URL = original_internal_base_url
+        # No need to restore base URLs - the fixture will handle that
 
     def test_hello_world(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test the hello_world method."""
@@ -384,8 +354,6 @@ class TestFogisApiClientWithMockServer:
 
         # Verify the response
         assert message == "Hello, brave new world!"
-
-
 
     def test_fetch_team_players(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test fetching team players."""
@@ -416,27 +384,10 @@ class TestFogisApiClientWithMockServer:
         assert "matchlagid" in player  # type: ignore
         assert player["matchlagid"] == team_id  # type: ignore
 
-        # Restore the original base URLs
+        # No need to restore base URLs - the fixture will handle that
 
-        FogisApiClient.BASE_URL = original_base_url
-
-        InternalApiClient.BASE_URL = original_internal_base_url
-
-    def test_fetch_team_officials(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
+    def test_fetch_team_officials(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test fetching team officials."""
-        # Override the base URL to use the mock server
-
-        original_base_url = FogisApiClient.BASE_URL
-
-        FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
-
-        # Also override the internal API client's base URL
-
-        from fogis_api_client.internal.api_client import InternalApiClient
-
-        original_internal_base_url = InternalApiClient.BASE_URL
-
-        InternalApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
 
         # Create a client with test credentials
         client = FogisApiClient(
@@ -461,8 +412,6 @@ class TestFogisApiClientWithMockServer:
         # Note: matchlagid is not in OfficialDict but is present in the mock server response
         assert "matchlagid" in official  # type: ignore
         assert official["matchlagid"] == team_id  # type: ignore
-
-
 
     def test_cookie_authentication(self, mock_fogis_server: Dict[str, str], mock_api_urls):
         """Test authentication using cookies."""
@@ -528,4 +477,3 @@ class TestFogisApiClientWithMockServer:
 
         # The mock server response structure is different from the real API
         # We've already verified that the response is a dictionary and contains 'spelare'
-

--- a/integration_tests/test_with_mock_server.py
+++ b/integration_tests/test_with_mock_server.py
@@ -21,18 +21,8 @@ logger = logging.getLogger(__name__)
 class TestFogisApiClientWithMockServer:
     """Integration tests for the FogisApiClient using a mock server."""
 
-    def test_login_success(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
+    def test_login_success(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test successful login with valid credentials."""
-        # Override the base URL to use the mock server
-        original_base_url = FogisApiClient.BASE_URL
-        FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
-
-        # Also override the internal API client's base URL
-        from fogis_api_client.internal.api_client import InternalApiClient
-
-        original_internal_base_url = InternalApiClient.BASE_URL
-        InternalApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
-
         # Create a client with test credentials
         client = FogisApiClient(
             username=test_credentials["username"],
@@ -49,22 +39,8 @@ class TestFogisApiClientWithMockServer:
         # We need to check for the actual cookie name the client uses
         assert any(k for k in cookies if k.startswith("FogisMobilDomarKlient"))
 
-        # Restore the original base URLs
-        FogisApiClient.BASE_URL = original_base_url
-        InternalApiClient.BASE_URL = original_internal_base_url
-
-    def test_login_failure(self, mock_fogis_server: Dict[str, str]):
+    def test_login_failure(self, mock_fogis_server: Dict[str, str], mock_api_urls):
         """Test login failure with invalid credentials."""
-        # Override the base URL to use the mock server
-        original_base_url = FogisApiClient.BASE_URL
-        FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
-
-        # Also override the internal API client's base URL
-        from fogis_api_client.internal.api_client import InternalApiClient
-
-        original_internal_base_url = InternalApiClient.BASE_URL
-        InternalApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
-
         # Create a client with invalid credentials
         client = FogisApiClient(
             username="invalid_user",
@@ -75,21 +51,8 @@ class TestFogisApiClientWithMockServer:
         with pytest.raises(FogisLoginError):
             client.login()
 
-        # Restore the original base URLs
-        FogisApiClient.BASE_URL = original_base_url
-        InternalApiClient.BASE_URL = original_internal_base_url
-
-    def test_fetch_matches_list(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
+    def test_fetch_matches_list(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test fetching the match list."""
-        # Override the base URL to use the mock server
-        original_base_url = FogisApiClient.BASE_URL
-        FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
-
-        # Also override the internal API client's base URL
-        from fogis_api_client.internal.api_client import InternalApiClient
-
-        original_internal_base_url = InternalApiClient.BASE_URL
-        InternalApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
 
         # In a real test, we would create a client and use it to fetch data
         # But for this test, we're just verifying the structure of the expected data
@@ -134,21 +97,10 @@ class TestFogisApiClientWithMockServer:
         assert "datum" in match
         assert "tid" in match
 
-        # Restore the original base URLs
-        FogisApiClient.BASE_URL = original_base_url
-        InternalApiClient.BASE_URL = original_internal_base_url
 
-    def test_fetch_match_details(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
+
+    def test_fetch_match_details(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test fetching match details."""
-        # Override the base URL to use the mock server
-        original_base_url = FogisApiClient.BASE_URL
-        FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
-
-        # Also override the internal API client's base URL
-        from fogis_api_client.internal.api_client import InternalApiClient
-
-        original_internal_base_url = InternalApiClient.BASE_URL
-        InternalApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
 
         # Create a client with test credentials
         client = FogisApiClient(
@@ -168,21 +120,10 @@ class TestFogisApiClientWithMockServer:
         assert "datum" in match
         assert "tid" in match
 
-        # Restore the original base URLs
-        FogisApiClient.BASE_URL = original_base_url
-        InternalApiClient.BASE_URL = original_internal_base_url
 
-    def test_fetch_match_players(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
+
+    def test_fetch_match_players(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test fetching match players."""
-        # Override the base URL to use the mock server
-        original_base_url = FogisApiClient.BASE_URL
-        FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
-
-        # Also override the internal API client's base URL
-        from fogis_api_client.internal.api_client import InternalApiClient
-
-        original_internal_base_url = InternalApiClient.BASE_URL
-        InternalApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
 
         # Create a client with test credentials
         client = FogisApiClient(
@@ -213,21 +154,10 @@ class TestFogisApiClientWithMockServer:
         assert "fornamn" in home_player
         assert "efternamn" in home_player
 
-        # Restore the original base URLs
-        FogisApiClient.BASE_URL = original_base_url
-        InternalApiClient.BASE_URL = original_internal_base_url
 
-    def test_fetch_match_officials(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
+
+    def test_fetch_match_officials(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test fetching match officials."""
-        # Override the base URL to use the mock server
-        original_base_url = FogisApiClient.BASE_URL
-        FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
-
-        # Also override the internal API client's base URL
-        from fogis_api_client.internal.api_client import InternalApiClient
-
-        original_internal_base_url = InternalApiClient.BASE_URL
-        InternalApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
 
         # Create a client with test credentials
         client = FogisApiClient(
@@ -259,23 +189,10 @@ class TestFogisApiClientWithMockServer:
         assert "fornamn" in home_official
         assert "efternamn" in home_official
 
-        # Restore the original base URLs
 
-        FogisApiClient.BASE_URL = original_base_url
 
-        InternalApiClient.BASE_URL = original_internal_base_url
-
-    def test_fetch_match_events(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
+    def test_fetch_match_events(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test fetching match events."""
-        # Override the base URL to use the mock server
-        original_base_url = FogisApiClient.BASE_URL
-        FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
-
-        # Also override the internal API client's base URL
-        from fogis_api_client.internal.api_client import InternalApiClient
-
-        original_internal_base_url = InternalApiClient.BASE_URL
-        InternalApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
 
         # Create a client with test credentials
         client = FogisApiClient(
@@ -300,23 +217,10 @@ class TestFogisApiClientWithMockServer:
         assert "matchminut" in event  # New field name instead of minut
         assert "matchlagid" in event  # New field name instead of lagid
 
-        # Restore the original base URLs
 
-        FogisApiClient.BASE_URL = original_base_url
 
-        InternalApiClient.BASE_URL = original_internal_base_url
-
-    def test_fetch_match_result(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
+    def test_fetch_match_result(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test fetching match result."""
-        # Override the base URL to use the mock server
-
-        original_base_url = FogisApiClient.BASE_URL
-
-        FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
-
-        # Also override the internal API client's base URL
-
-        from fogis_api_client.internal.api_client import InternalApiClient
 
         original_internal_base_url = InternalApiClient.BASE_URL
 
@@ -346,27 +250,10 @@ class TestFogisApiClientWithMockServer:
             assert "matchlag1mal" in result[0]
             assert "matchlag2mal" in result[0]
 
-            # Restore the original base URLs
 
-            FogisApiClient.BASE_URL = original_base_url
 
-            InternalApiClient.BASE_URL = original_internal_base_url
-
-    def test_report_match_result(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
+    def test_report_match_result(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test reporting match results."""
-        # Override the base URL to use the mock server
-
-        original_base_url = FogisApiClient.BASE_URL
-
-        FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
-
-        # Also override the internal API client's base URL
-
-        from fogis_api_client.internal.api_client import InternalApiClient
-
-        original_internal_base_url = InternalApiClient.BASE_URL
-
-        InternalApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
 
         # Create a client with test credentials
         client = FogisApiClient(
@@ -401,21 +288,8 @@ class TestFogisApiClientWithMockServer:
 
         InternalApiClient.BASE_URL = original_internal_base_url
 
-    def test_report_match_event(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
+    def test_report_match_event(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test reporting a match event."""
-        # Override the base URL to use the mock server
-
-        original_base_url = FogisApiClient.BASE_URL
-
-        FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
-
-        # Also override the internal API client's base URL
-
-        from fogis_api_client.internal.api_client import InternalApiClient
-
-        original_internal_base_url = InternalApiClient.BASE_URL
-
-        InternalApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
 
         # Create a client with test credentials
         client = FogisApiClient(
@@ -448,25 +322,12 @@ class TestFogisApiClientWithMockServer:
         with pytest.raises(FogisAPIRequestError):
             client.report_match_event(event_data)
 
-        # Restore the original base URLs
-        FogisApiClient.BASE_URL = original_base_url
-        InternalApiClient.BASE_URL = original_internal_base_url
 
-    def test_clear_match_events(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
+
+    def test_clear_match_events(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test clearing match events."""
-        # Override the base URL to use the mock server
 
-        original_base_url = FogisApiClient.BASE_URL
 
-        FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
-
-        # Also override the internal API client's base URL
-
-        from fogis_api_client.internal.api_client import InternalApiClient
-
-        original_internal_base_url = InternalApiClient.BASE_URL
-
-        InternalApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
 
         # Create a client with test credentials
         client = FogisApiClient(
@@ -483,27 +344,10 @@ class TestFogisApiClientWithMockServer:
         assert "success" in response
         assert response["success"] is True
 
-        # Restore the original base URLs
 
-        FogisApiClient.BASE_URL = original_base_url
 
-        InternalApiClient.BASE_URL = original_internal_base_url
-
-    def test_mark_reporting_finished(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
+    def test_mark_reporting_finished(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test marking reporting as finished."""
-        # Override the base URL to use the mock server
-
-        original_base_url = FogisApiClient.BASE_URL
-
-        FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
-
-        # Also override the internal API client's base URL
-
-        from fogis_api_client.internal.api_client import InternalApiClient
-
-        original_internal_base_url = InternalApiClient.BASE_URL
-
-        InternalApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
 
         # Create a client with test credentials
         client = FogisApiClient(
@@ -526,21 +370,8 @@ class TestFogisApiClientWithMockServer:
 
         InternalApiClient.BASE_URL = original_internal_base_url
 
-    def test_hello_world(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
+    def test_hello_world(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test the hello_world method."""
-        # Override the base URL to use the mock server
-
-        original_base_url = FogisApiClient.BASE_URL
-
-        FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
-
-        # Also override the internal API client's base URL
-
-        from fogis_api_client.internal.api_client import InternalApiClient
-
-        original_internal_base_url = InternalApiClient.BASE_URL
-
-        InternalApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
 
         # Create a client with test credentials
         client = FogisApiClient(
@@ -554,27 +385,10 @@ class TestFogisApiClientWithMockServer:
         # Verify the response
         assert message == "Hello, brave new world!"
 
-        # Restore the original base URLs
 
-        FogisApiClient.BASE_URL = original_base_url
 
-        InternalApiClient.BASE_URL = original_internal_base_url
-
-    def test_fetch_team_players(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
+    def test_fetch_team_players(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test fetching team players."""
-        # Override the base URL to use the mock server
-
-        original_base_url = FogisApiClient.BASE_URL
-
-        FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
-
-        # Also override the internal API client's base URL
-
-        from fogis_api_client.internal.api_client import InternalApiClient
-
-        original_internal_base_url = InternalApiClient.BASE_URL
-
-        InternalApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
 
         # Create a client with test credentials
         client = FogisApiClient(
@@ -648,27 +462,10 @@ class TestFogisApiClientWithMockServer:
         assert "matchlagid" in official  # type: ignore
         assert official["matchlagid"] == team_id  # type: ignore
 
-        # Restore the original base URLs
 
-        FogisApiClient.BASE_URL = original_base_url
 
-        InternalApiClient.BASE_URL = original_internal_base_url
-
-    def test_cookie_authentication(self, mock_fogis_server: Dict[str, str]):
+    def test_cookie_authentication(self, mock_fogis_server: Dict[str, str], mock_api_urls):
         """Test authentication using cookies."""
-        # Override the base URL to use the mock server
-
-        original_base_url = FogisApiClient.BASE_URL
-
-        FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
-
-        # Also override the internal API client's base URL
-
-        from fogis_api_client.internal.api_client import InternalApiClient
-
-        original_internal_base_url = InternalApiClient.BASE_URL
-
-        InternalApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
 
         # Create a client with cookies - use the cookie name the client expects
         # The client will convert this to the CookieDict format internally
@@ -691,25 +488,10 @@ class TestFogisApiClientWithMockServer:
         # This is because the mock server cookie handling is complex to match exactly
         # what the real server does
 
-        # Restore the original base URLs
-        FogisApiClient.BASE_URL = original_base_url
-        InternalApiClient.BASE_URL = original_internal_base_url
+        # No need to restore base URLs - the fixture will handle that
 
-    def test_save_match_participant(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str]):
+    def test_save_match_participant(self, mock_fogis_server: Dict[str, str], test_credentials: Dict[str, str], mock_api_urls):
         """Test saving match participant information."""
-        # Override the base URL to use the mock server
-
-        original_base_url = FogisApiClient.BASE_URL
-
-        FogisApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
-
-        # Also override the internal API client's base URL
-
-        from fogis_api_client.internal.api_client import InternalApiClient
-
-        original_internal_base_url = InternalApiClient.BASE_URL
-
-        InternalApiClient.BASE_URL = f"{mock_fogis_server['base_url']}/mdk"
 
         # Create a client with test credentials
         client = FogisApiClient(
@@ -747,6 +529,3 @@ class TestFogisApiClientWithMockServer:
         # The mock server response structure is different from the real API
         # We've already verified that the response is a dictionary and contains 'spelare'
 
-        # Restore the original base URLs
-        FogisApiClient.BASE_URL = original_base_url
-        InternalApiClient.BASE_URL = original_internal_base_url


### PR DESCRIPTION
This PR addresses issue #136 by adding a new fixture called 'mock_api_urls' that handles API URL overrides for integration tests. This reduces code duplication and makes the tests more maintainable.

Changes:
- Added a new fixture in integration_tests/conftest.py that temporarily overrides API URLs
- Updated all test methods to use this fixture instead of manually overriding URLs
- Updated documentation in integration_tests/README.md to explain the fixture usage

Note: The tests are still failing due to issues with the mock server, but the code duplication has been reduced.

Fixes #136