### PR TITLE
Add organization-wide workflows (main)

### DIFF
--- a/.github/workflows/ci-failure-reminder.yml
+++ b/.github/workflows/ci-failure-reminder.yml
@@ -1,0 +1,11 @@
+name: CI Failure Reminder
+
+on:
+  workflow_run:
+    workflows: ["CI", "Build", "Test"]
+    types:
+      - completed
+
+jobs:
+  remind-on-failure:
+    uses: PitchConnect/.github/.github/workflows/ci-failure-reminder.yml@main

--- a/.github/workflows/contributing-reminder.yml
+++ b/.github/workflows/contributing-reminder.yml
@@ -1,0 +1,13 @@
+name: Contributing Guidelines Reminder
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  check-contributing-reference:
+    uses: PitchConnect/.github/.github/workflows/contributing-reminder.yml@main
+    with:
+      contributing_url: 'https://github.com/PitchConnect/contribution-guidelines/blob/main/CONTRIBUTING.md'

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,14 @@
+name: Issue Labeler
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  label-issue:
+    uses: PitchConnect/.github/.github/workflows/issue-labeler.yml@main
+    permissions:
+      issues: write
+      contents: read
+    with:
+      label_name: 'triage'

--- a/.github/workflows/label-creator.yml
+++ b/.github/workflows/label-creator.yml
@@ -1,0 +1,11 @@
+name: Label Creator
+
+on:
+  workflow_dispatch:
+
+jobs:
+  create-labels:
+    uses: PitchConnect/.github/.github/workflows/label-creator.yml@main
+    permissions:
+      issues: write
+      contents: read

--- a/.github/workflows/pr-status-tracker.yml
+++ b/.github/workflows/pr-status-tracker.yml
@@ -1,0 +1,13 @@
+name: PR Status Tracker
+
+on:
+  pull_request:
+    types: [opened, converted_to_draft, ready_for_review, closed]
+
+jobs:
+  track-pr-status:
+    uses: PitchConnect/.github/.github/workflows/pr-status-tracker.yml@main
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: read

--- a/.github/workflows/release-pr-generator.yml
+++ b/.github/workflows/release-pr-generator.yml
@@ -1,0 +1,14 @@
+name: Release PR Generator
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g., 1.2.0)'
+        required: true
+
+jobs:
+  generate-release-pr:
+    uses: PitchConnect/.github/.github/workflows/release-pr-generator.yml@main
+    with:
+      version: ${{ github.event.inputs.version }}


### PR DESCRIPTION
# Add Organization-Wide Workflows

This PR adds organization-wide workflows to the repository:

1. **Issue Labeler**: Automatically adds a "triage" label to new issues
2. **Contributing Guidelines Reminder**: Checks if issues/PRs reference CONTRIBUTING.md
3. **PR Status Tracker**: Updates issue labels based on PR status
4. **Label Creator**: Creates standard labels in the repository
5. **CI Failure Reminder**: Reminds about pre-commit hooks on CI failure
6. **Release PR Generator**: Generates release PRs with all pending issues

## Benefits

1. **Automated Issue Tracking**: Issues are automatically labeled and tracked through the development lifecycle
2. **Consistent Process**: Ensures a consistent process across all repositories
3. **Reduced Manual Work**: Automates repetitive tasks
4. **Better Visibility**: Provides better visibility into the status of issues and PRs

## After Merging

After merging this PR, please run the Label Creator workflow to create the standard labels in the repository:

1. Go to the "Actions" tab
2. Select the "Label Creator" workflow
3. Click "Run workflow"
4. Click "Run workflow" again to confirm

## Important Note

This PR is for the `main` branch. A separate PR has been created for the `develop` branch to ensure that the workflows are available on both branches.
