### PR TITLE
Enhance error assertions and test isolation in integration tests

### DIFF
--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -130,6 +130,23 @@ def test_credentials() -> Dict[str, str]:
 
 
 @pytest.fixture
+def clear_request_history(mock_fogis_server: Dict[str, str]) -> None:
+    """
+    Fixture that clears the request history before each test.
+
+    This ensures test isolation by preventing previous test requests from affecting current tests.
+
+    Args:
+        mock_fogis_server: The mock server information
+    """
+    # Clear request history at the beginning of the test
+    requests.post(f"{mock_fogis_server['base_url']}/clear-request-history")
+    yield
+    # Optionally clear again after the test (not strictly necessary but helps with debugging)
+    requests.post(f"{mock_fogis_server['base_url']}/clear-request-history")
+
+
+@pytest.fixture
 def mock_api_urls(mock_fogis_server: Dict[str, str]) -> None:
     """
     Temporarily override API URLs to point to mock server.


### PR DESCRIPTION
## Description
This PR enhances the integration tests by:

1. Adding more specific error message assertions to tests that use  to verify that error messages contain useful information
2. Creating a  fixture to ensure test isolation
3. Updating all tests to use the new fixture
4. Removing redundant  calls from individual tests

## Related Issues
Fixes #164

## Testing
All integration tests in  and  pass successfully.

## Checklist
- [x] I have followed the contribution guidelines
- [x] I have run the pre-commit hooks
- [x] I have tested my changes
- [x] I have updated the documentation (if applicable)
