### PR TITLE
Hotfix #187: Revert property name changes to maintain backward compatibility (main)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.4.3] - 2025-05-20
+
+### Fixed
+- Reverted property name changes to maintain backward compatibility (Issue #187)
+- Restored original property names in API client: matchhandelsetypid, matchminut, matchlagid, spelareid, hemmamal, bortamal
+- Updated validation schemas to accept both original and new property names
+- Fixed adapters to properly handle original property names
+
 ## [0.4.2] - 2025-05-15
 
 ### Fixed

--- a/fogis_api_client/api_contracts.py
+++ b/fogis_api_client/api_contracts.py
@@ -1,0 +1,77 @@
+"""
+API contract definitions for FOGIS API client.
+
+This module contains JSON Schema definitions for the API contracts that must be
+maintained when interacting with the FOGIS API. These schemas define the expected
+structure of data sent to and received from the API.
+
+The schemas are used for:
+1. Validating request payloads before sending to the API
+2. Validating response data from the API
+3. Testing API interactions to ensure contract compliance
+4. Documenting the required data structures
+
+Usage:
+    from fogis_api_client.api_contracts import (
+        validate_request,
+        validate_response,
+        REQUEST_SCHEMAS,
+        RESPONSE_SCHEMAS,
+        ValidationConfig,
+    )
+
+    # Configure validation
+    ValidationConfig.enable_validation = True
+    ValidationConfig.strict_mode = True
+
+    # Validate a request payload
+    validate_request('/MatchWebMetoder.aspx/SparaMatchresultatLista', payload)
+
+    # Validate a response
+    validate_response('/MatchWebMetoder.aspx/GetMatchresultatlista', response_data)
+"""
+import logging
+import re
+import warnings
+from typing import Any, Dict, Optional
+
+import jsonschema
+from jsonschema import ValidationError
+
+# Import from internal module
+from fogis_api_client.internal.api_contracts import (
+    MATCH_EVENT_DELETE_SCHEMA,
+    MATCH_EVENT_SCHEMA,
+    MATCH_FETCH_SCHEMA,
+    MATCH_LIST_FILTER_SCHEMA,
+    MATCH_PARTICIPANT_SCHEMA,
+    MATCH_RESULT_FLAT_SCHEMA,
+    MATCH_RESULT_NESTED_SCHEMA,
+    MARK_REPORTING_FINISHED_SCHEMA,
+    REQUEST_SCHEMAS,
+    RESPONSE_SCHEMAS,
+    TEAM_OFFICIAL_ACTION_SCHEMA,
+    ValidationConfig,
+    convert_flat_to_nested_match_result,
+    extract_endpoint_from_url,
+    get_schema_for_endpoint,
+    validate_request,
+    validate_response,
+)
+
+# Configure logging
+logger = logging.getLogger(__name__)
+
+# Emit a deprecation warning
+warnings.warn(
+    "The fogis_api_client.api_contracts module is deprecated. "
+    "Use fogis_api_client.internal.api_contracts instead.",
+    DeprecationWarning,
+    stacklevel=2
+)
+
+
+# ValidationConfig is imported from internal module
+
+
+# All schemas and functions are imported from internal module

--- a/fogis_api_client/internal/README.md
+++ b/fogis_api_client/internal/README.md
@@ -1,0 +1,58 @@
+# Internal API Layer
+
+This module contains the internal implementation details of the FOGIS API client.
+It is not intended to be used directly by users of the library.
+
+## Purpose
+
+The internal API layer is responsible for:
+
+1. Communicating with the FOGIS API server
+2. Converting between public and internal data formats
+3. Handling authentication and session management
+4. Implementing the low-level API contracts
+
+This separation allows the public API to focus on usability and type safety,
+while the internal API ensures compatibility with the server requirements.
+
+## Architecture
+
+The internal API layer consists of the following components:
+
+- `api_client.py`: The internal API client that handles communication with the FOGIS API server
+- `api_contracts.py`: JSON Schema definitions for the API contracts
+- `auth.py`: Authentication module for the FOGIS API client
+- `types.py`: Internal type definitions for the FOGIS API client
+- `adapters.py`: Adapters for converting between public and internal data formats
+
+## Usage
+
+The internal API layer is not intended to be used directly by users of the library.
+Instead, users should use the public API client (`FogisApiClient`) which provides
+a simpler, more user-friendly interface.
+
+```python
+# Don't do this
+from fogis_api_client.internal.api_client import InternalApiClient
+
+# Do this instead
+from fogis_api_client import FogisApiClient
+```
+
+## Development
+
+When developing the FOGIS API client, you should follow these guidelines:
+
+1. Keep the public API stable and backward-compatible
+2. Make changes to the internal API layer when necessary to accommodate server changes
+3. Use the adapters to convert between public and internal data formats
+4. Add tests for both the public and internal API layers
+5. Document any changes to the internal API layer
+
+## Testing
+
+The internal API layer is tested using unit tests. You can run the tests with:
+
+```bash
+python -m pytest tests/test_internal_api.py
+```

--- a/fogis_api_client/internal/__init__.py
+++ b/fogis_api_client/internal/__init__.py
@@ -1,0 +1,15 @@
+"""
+Internal API layer for the FOGIS API client.
+
+This module contains the internal implementation details of the FOGIS API client.
+It is not intended to be used directly by users of the library.
+
+The internal API layer is responsible for:
+1. Communicating with the FOGIS API server
+2. Converting between public and internal data formats
+3. Handling authentication and session management
+4. Implementing the low-level API contracts
+
+This separation allows the public API to focus on usability and type safety,
+while the internal API ensures compatibility with the server requirements.
+"""

--- a/fogis_api_client/internal/adapters.py
+++ b/fogis_api_client/internal/adapters.py
@@ -1,0 +1,385 @@
+"""
+Adapters for converting between public and internal data formats.
+
+This module contains functions for converting between the public API data formats
+(what users of the library work with) and the internal API data formats
+(what the FOGIS API server expects).
+"""
+import json
+from typing import Any, Dict, List, Optional, Union, cast
+
+from fogis_api_client.types import (
+    CookieDict,
+    EventDict,
+    MatchDict,
+    MatchParticipantDict,
+    MatchResultDict,
+    OfficialActionDict,
+    OfficialDict,
+    PlayerDict,
+    TeamPlayersResponse,
+)
+
+from .types import (
+    InternalCookieDict,
+    InternalEventDict,
+    InternalMatchDict,
+    InternalMatchListResponse,
+    InternalMatchParticipantDict,
+    InternalMatchResultDict,
+    InternalMatchResultItem,
+    InternalOfficialActionDict,
+    InternalOfficialDict,
+    InternalPlayerDict,
+    InternalTeamPlayersResponse,
+)
+
+
+def convert_match_result_to_internal(
+    result_data: Union[MatchResultDict, Dict[str, Any]]
+) -> InternalMatchResultDict:
+    """
+    Converts a public match result to the internal format expected by the API.
+
+    Args:
+        result_data: Match result data in either flat or nested format
+
+    Returns:
+        InternalMatchResultDict: Match result in the internal format
+
+    Raises:
+        ValueError: If required fields are missing
+    """
+    # If already in the nested format, just return a deep copy
+    if "matchresultatListaJSON" in result_data:
+        # Create a deep copy to avoid modifying the original
+        result_data_copy = json.loads(json.dumps(result_data))
+
+        # Ensure numeric fields are integers in each result object
+        for result_obj in result_data_copy.get("matchresultatListaJSON", []):
+            for field in ["matchid", "matchresultattypid", "matchlag1mal", "matchlag2mal"]:
+                if field in result_obj and result_obj[field] is not None:
+                    value = result_obj[field]
+                    if isinstance(value, str):
+                        result_obj[field] = int(value)
+
+        return cast(InternalMatchResultDict, result_data_copy)
+
+    # Otherwise, convert from flat format to nested format
+    match_id = int(result_data["matchid"]) if isinstance(result_data["matchid"], str) else result_data["matchid"]
+    fulltime_home = int(result_data["hemmamal"]) if isinstance(result_data["hemmamal"], str) else result_data["hemmamal"]
+    fulltime_away = int(result_data["bortamal"]) if isinstance(result_data["bortamal"], str) else result_data["bortamal"]
+
+    # Half-time scores are optional
+    halftime_home = 0
+    if "halvtidHemmamal" in result_data and result_data["halvtidHemmamal"] is not None:
+        halftime_home = int(result_data["halvtidHemmamal"]) if isinstance(result_data["halvtidHemmamal"], str) else result_data["halvtidHemmamal"]
+
+    halftime_away = 0
+    if "halvtidBortamal" in result_data and result_data["halvtidBortamal"] is not None:
+        halftime_away = int(result_data["halvtidBortamal"]) if isinstance(result_data["halvtidBortamal"], str) else result_data["halvtidBortamal"]
+
+    # Create the nested structure
+    nested_data: InternalMatchResultDict = {
+        "matchresultatListaJSON": [
+            {
+                "matchid": match_id,
+                "matchresultattypid": 1,  # Full time
+                "matchlag1mal": fulltime_home,
+                "matchlag2mal": fulltime_away,
+                "wo": False,
+                "ow": False,
+                "ww": False,
+            },
+            {
+                "matchid": match_id,
+                "matchresultattypid": 2,  # Half-time
+                "matchlag1mal": halftime_home,
+                "matchlag2mal": halftime_away,
+                "wo": False,
+                "ow": False,
+                "ww": False,
+            },
+        ]
+    }
+
+    return nested_data
+
+
+def convert_internal_to_match_result(
+    internal_result: Union[Dict[str, Any], List[Dict[str, Any]]]
+) -> MatchResultDict:
+    """
+    Converts an internal match result to the public format.
+
+    Args:
+        internal_result: Match result data from the API
+
+    Returns:
+        MatchResultDict: Match result in the public format
+    """
+    # Handle different response formats
+    if isinstance(internal_result, list):
+        # If it's a list, find the full-time and half-time results
+        fulltime_result = None
+        halftime_result = None
+
+        for result in internal_result:
+            if result.get("matchresultattypid") == 1:  # Full-time
+                fulltime_result = result
+            elif result.get("matchresultattypid") == 2:  # Half-time
+                halftime_result = result
+
+        if not fulltime_result:
+            # If no full-time result found, use the first item
+            fulltime_result = internal_result[0] if internal_result else {}
+
+        match_id = fulltime_result.get("matchid")
+        hemmamal = fulltime_result.get("matchlag1mal", 0)
+        bortamal = fulltime_result.get("matchlag2mal", 0)
+
+        result_dict: MatchResultDict = {
+            "matchid": match_id,
+            "hemmamal": hemmamal,
+            "bortamal": bortamal,
+        }
+
+        # Add half-time scores if available
+        if halftime_result:
+            result_dict["halvtidHemmamal"] = halftime_result.get("matchlag1mal", 0)
+            result_dict["halvtidBortamal"] = halftime_result.get("matchlag2mal", 0)
+
+        return result_dict
+
+    elif isinstance(internal_result, dict):
+        # If it's a dictionary, it might be a direct result or have a nested structure
+        if "matchresultatListaJSON" in internal_result:
+            # Nested structure, extract the results
+            return convert_internal_to_match_result(internal_result["matchresultatListaJSON"])
+
+        # Direct result format (might be from a different endpoint)
+        result_dict: MatchResultDict = {
+            "matchid": internal_result.get("matchid", 0),
+            "hemmamal": internal_result.get("hemmamal", 0),
+            "bortamal": internal_result.get("bortamal", 0),
+        }
+
+        # Add half-time scores if available
+        if "halvtidHemmamal" in internal_result:
+            result_dict["halvtidHemmamal"] = internal_result.get("halvtidHemmamal", 0)
+        if "halvtidBortamal" in internal_result:
+            result_dict["halvtidBortamal"] = internal_result.get("halvtidBortamal", 0)
+
+        return result_dict
+
+    # Fallback for unexpected formats
+    return {"matchid": 0, "hemmamal": 0, "bortamal": 0}
+
+
+def convert_event_to_internal(event_data: EventDict) -> InternalEventDict:
+    """
+    Converts a public event to the internal format expected by the API.
+
+    Args:
+        event_data: Event data in the public format
+
+    Returns:
+        InternalEventDict: Event data in the internal format
+    """
+    # Create a copy to avoid modifying the original
+    event_data_copy = dict(event_data)
+
+    # Ensure numeric fields are integers
+    for field in [
+        "matchid",
+        "matchhandelsetypid",
+        "matchminut",
+        "matchlagid",
+        "spelareid",
+        "assisterandeid",
+        "period",
+        "hemmamal",
+        "bortamal",
+    ]:
+        if field in event_data_copy and event_data_copy[field] is not None:
+            value = event_data_copy[field]
+            if isinstance(value, str):
+                event_data_copy[field] = int(value)
+
+    return cast(InternalEventDict, event_data_copy)
+
+
+def convert_internal_to_event(internal_event: Dict[str, Any]) -> EventDict:
+    """
+    Converts an internal event to the public format.
+
+    Args:
+        internal_event: Event data from the API
+
+    Returns:
+        EventDict: Event data in the public format
+    """
+    # For now, the formats are the same, so we just cast
+    return cast(EventDict, internal_event)
+
+
+def convert_internal_to_match(internal_match: Dict[str, Any]) -> MatchDict:
+    """
+    Converts an internal match to the public format.
+
+    Args:
+        internal_match: Match data from the API
+
+    Returns:
+        MatchDict: Match data in the public format
+    """
+    # For now, the formats are the same, so we just cast
+    return cast(MatchDict, internal_match)
+
+
+def convert_internal_to_player(internal_player: Dict[str, Any]) -> PlayerDict:
+    """
+    Converts an internal player to the public format.
+
+    Args:
+        internal_player: Player data from the API
+
+    Returns:
+        PlayerDict: Player data in the public format
+    """
+    # For now, the formats are the same, so we just cast
+    return cast(PlayerDict, internal_player)
+
+
+def convert_internal_to_official(internal_official: Dict[str, Any]) -> OfficialDict:
+    """
+    Converts an internal official to the public format.
+
+    Args:
+        internal_official: Official data from the API
+
+    Returns:
+        OfficialDict: Official data in the public format
+    """
+    # For now, the formats are the same, so we just cast
+    return cast(OfficialDict, internal_official)
+
+
+def convert_official_action_to_internal(
+    action_data: OfficialActionDict
+) -> InternalOfficialActionDict:
+    """
+    Converts a public official action to the internal format expected by the API.
+
+    Args:
+        action_data: Official action data in the public format
+
+    Returns:
+        InternalOfficialActionDict: Official action data in the internal format
+    """
+    # Create a copy to avoid modifying the original
+    action_data_copy = dict(action_data)
+
+    # Map field names
+    field_mapping = {
+        "lagid": "matchlagid",
+        "personid": "matchlagledareid",
+        "minut": "matchminut",
+    }
+
+    # Convert field names
+    for old_field, new_field in field_mapping.items():
+        if old_field in action_data_copy:
+            action_data_copy[new_field] = action_data_copy.pop(old_field)
+
+    # Ensure IDs are integers
+    for key in ["matchid", "matchlagid", "matchlagledareid", "matchlagledaretypid", "matchminut"]:
+        if key in action_data_copy and action_data_copy[key] is not None:
+            value = action_data_copy[key]
+            if isinstance(value, str):
+                action_data_copy[key] = int(value)
+
+    return cast(InternalOfficialActionDict, action_data_copy)
+
+
+def convert_match_participant_to_internal(
+    participant_data: MatchParticipantDict
+) -> InternalMatchParticipantDict:
+    """
+    Converts a public match participant to the internal format expected by the API.
+
+    Args:
+        participant_data: Match participant data in the public format
+
+    Returns:
+        InternalMatchParticipantDict: Match participant data in the internal format
+    """
+    # Create a copy to avoid modifying the original
+    participant_data_copy = dict(participant_data)
+
+    # Ensure numeric fields are integers
+    for field in ["matchdeltagareid", "trojnummer", "lagdelid", "positionsnummerhv"]:
+        if field in participant_data_copy and participant_data_copy[field] is not None:
+            value = participant_data_copy[field]
+            if isinstance(value, str):
+                participant_data_copy[field] = int(value)
+
+    # Ensure boolean fields are booleans
+    for field in ["lagkapten", "ersattare", "arSpelandeLedare", "ansvarig"]:
+        if field in participant_data_copy and participant_data_copy[field] is not None:
+            value = participant_data_copy[field]
+            if not isinstance(value, bool):
+                participant_data_copy[field] = bool(value)
+
+    return cast(InternalMatchParticipantDict, participant_data_copy)
+
+
+def convert_cookies_to_internal(cookies: CookieDict) -> InternalCookieDict:
+    """
+    Converts public cookies to the internal format.
+
+    Args:
+        cookies: Cookies in the public format
+
+    Returns:
+        InternalCookieDict: Cookies in the internal format
+    """
+    # For now, the formats are the same, so we just cast
+    return cast(InternalCookieDict, cookies)
+
+
+def convert_internal_to_cookies(internal_cookies: Dict[str, str]) -> CookieDict:
+    """
+    Converts internal cookies to the public format.
+
+    Args:
+        internal_cookies: Cookies from the API
+
+    Returns:
+        CookieDict: Cookies in the public format
+    """
+    # For now, the formats are the same, so we just cast
+    return cast(CookieDict, internal_cookies)
+
+
+def convert_internal_to_team_players(
+    internal_response: Dict[str, Any]
+) -> TeamPlayersResponse:
+    """
+    Converts an internal team players response to the public format.
+
+    Args:
+        internal_response: Team players data from the API
+
+    Returns:
+        TeamPlayersResponse: Team players data in the public format
+    """
+    # For tests that expect a dictionary with 'spelare' key
+    if isinstance(internal_response, dict) and "spelare" in internal_response:
+        return cast(TeamPlayersResponse, internal_response)
+    # For tests that expect a list - wrap it in a dictionary
+    elif isinstance(internal_response, list):
+        return cast(TeamPlayersResponse, {"spelare": internal_response})
+    else:
+        # Unexpected format, return empty response
+        return {"spelare": []}

--- a/fogis_api_client/internal/api_client.py
+++ b/fogis_api_client/internal/api_client.py
@@ -1,0 +1,464 @@
+"""
+Internal API client for communicating with the FOGIS API server.
+
+This module handles the low-level communication with the FOGIS API server,
+ensuring that the data sent to and received from the server matches the expected format.
+"""
+import json
+import logging
+import re
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional, Union, cast
+
+import requests
+from bs4 import BeautifulSoup
+from jsonschema import ValidationError
+
+from fogis_api_client.internal.api_contracts import extract_endpoint_from_url, validate_request, validate_response
+from fogis_api_client.internal.types import (
+    InternalCookieDict,
+    InternalEventDict,
+    InternalMatchDict,
+    InternalMatchListResponse,
+    InternalMatchParticipantDict,
+    InternalMatchResultDict,
+    InternalOfficialActionDict,
+    InternalOfficialDict,
+    InternalPlayerDict,
+    InternalTeamPlayersResponse,
+)
+
+
+class InternalApiError(Exception):
+    """Exception raised when an internal API request fails."""
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(self.message)
+
+
+class InternalApiClient:
+    """
+    Internal API client for communicating with the FOGIS API server.
+
+    This class handles the low-level communication with the FOGIS API server,
+    ensuring that the data sent to and received from the server matches the expected format.
+    """
+
+    BASE_URL: str = "https://fogis.svenskfotboll.se/mdk"
+    logger: logging.Logger = logging.getLogger("fogis_api_client.internal.api")
+
+    def __init__(self, session: requests.Session) -> None:
+        """
+        Initialize the internal API client.
+
+        Args:
+            session: The requests session to use for API calls
+        """
+        self.session = session
+
+    def api_request(self, url: str, payload: Dict[str, Any]) -> Any:
+        """
+        Make an API request to the FOGIS API server.
+
+        Args:
+            url: The URL to send the request to
+            payload: The payload to send with the request
+
+        Returns:
+            Any: The response data from the API
+
+        Raises:
+            InternalApiError: If the request fails
+        """
+        headers = {
+            "Content-Type": "application/json; charset=utf-8",
+            "Accept": "application/json, text/javascript, */*; q=0.01",
+            "X-Requested-With": "XMLHttpRequest",
+        }
+
+        # Check if the URL is using the default base URL and replace it with the current base URL
+        default_base_url = "https://fogis.svenskfotboll.se/mdk"
+        if url.startswith(default_base_url):
+            endpoint_path = url[len(default_base_url):]
+            url = f"{self.BASE_URL}{endpoint_path}"
+            self.logger.debug(f"Using current base URL: {url}")
+
+        # Extract the endpoint for validation
+        endpoint = extract_endpoint_from_url(url)
+
+        # Validate the request payload
+        try:
+            validate_request(endpoint, payload)
+        except ValidationError as e:
+            error_msg = f"Request validation failed: {e}"
+            self.logger.error(error_msg)
+            raise InternalApiError(error_msg) from e
+        except ValueError:
+            # No schema defined for this endpoint, just log and continue
+            self.logger.debug(f"No request schema defined for {endpoint}")
+
+        try:
+            response = self.session.post(url, json=payload, headers=headers)
+            response.raise_for_status()
+
+            # Parse the JSON response
+            response_data = response.json()
+
+            # Extract the 'd' field if it exists (FOGIS API wraps responses in a 'd' field)
+            if isinstance(response_data, dict) and "d" in response_data:
+                # The 'd' field contains a JSON string that needs to be parsed
+                try:
+                    parsed_data = json.loads(response_data["d"])
+
+                    # Validate the response
+                    try:
+                        validate_response(endpoint, parsed_data)
+                    except ValidationError as e:
+                        self.logger.warning(f"Response validation warning: {e}")
+                    except ValueError:
+                        # No schema defined for this response, just log and continue
+                        self.logger.debug(f"No response schema defined for {endpoint}")
+
+                    return parsed_data
+                except (json.JSONDecodeError, TypeError):
+                    # If parsing fails, return the raw 'd' field
+                    return response_data["d"]
+
+            return response_data
+
+        except requests.exceptions.RequestException as e:
+            error_msg = f"API request failed: {e}"
+            self.logger.error(error_msg)
+            raise InternalApiError(error_msg) from e
+
+    def get_matches_list(self, filter_params: Dict[str, Any]) -> InternalMatchListResponse:
+        """
+        Get the list of matches for the logged-in referee.
+
+        Args:
+            filter_params: Filter parameters for the match list
+
+        Returns:
+            InternalMatchListResponse: The match list response
+
+        Raises:
+            InternalApiError: If the request fails
+        """
+        url = f"{self.BASE_URL}/MatchWebMetoder.aspx/GetMatcherAttRapportera"
+
+        # Build the payload with the filter parameters
+        payload = {"filter": filter_params}
+
+        response_data = self.api_request(url, payload)
+
+        if not isinstance(response_data, dict) or "matchlista" not in response_data:
+            error_msg = f"Invalid match list response: {response_data}"
+            self.logger.error(error_msg)
+            raise InternalApiError(error_msg)
+
+        return cast(InternalMatchListResponse, response_data)
+
+    def get_match(self, match_id: int) -> InternalMatchDict:
+        """
+        Get detailed information for a specific match.
+
+        Args:
+            match_id: The ID of the match
+
+        Returns:
+            InternalMatchDict: The match details
+
+        Raises:
+            InternalApiError: If the request fails
+        """
+        url = f"{self.BASE_URL}/MatchWebMetoder.aspx/GetMatch"
+        payload = {"matchid": match_id}
+
+        response_data = self.api_request(url, payload)
+
+        if not isinstance(response_data, dict):
+            error_msg = f"Invalid match response: {response_data}"
+            self.logger.error(error_msg)
+            raise InternalApiError(error_msg)
+
+        return cast(InternalMatchDict, response_data)
+
+    def get_match_players(self, match_id: int) -> Dict[str, List[InternalPlayerDict]]:
+        """
+        Get player information for a specific match.
+
+        Args:
+            match_id: The ID of the match
+
+        Returns:
+            Dict[str, List[InternalPlayerDict]]: Player information for the match
+
+        Raises:
+            InternalApiError: If the request fails
+        """
+        url = f"{self.BASE_URL}/MatchWebMetoder.aspx/GetMatchdeltagareLista"
+        payload = {"matchid": match_id}
+
+        response_data = self.api_request(url, payload)
+
+        if not isinstance(response_data, dict):
+            error_msg = f"Invalid match players response: {response_data}"
+            self.logger.error(error_msg)
+            raise InternalApiError(error_msg)
+
+        return cast(Dict[str, List[InternalPlayerDict]], response_data)
+
+    def get_match_officials(self, match_id: int) -> Dict[str, List[InternalOfficialDict]]:
+        """
+        Get officials information for a specific match.
+
+        Args:
+            match_id: The ID of the match
+
+        Returns:
+            Dict[str, List[InternalOfficialDict]]: Officials information for the match
+
+        Raises:
+            InternalApiError: If the request fails
+        """
+        url = f"{self.BASE_URL}/MatchWebMetoder.aspx/GetMatchfunktionarerLista"
+        payload = {"matchid": match_id}
+
+        response_data = self.api_request(url, payload)
+
+        if not isinstance(response_data, dict):
+            error_msg = f"Invalid match officials response: {response_data}"
+            self.logger.error(error_msg)
+            raise InternalApiError(error_msg)
+
+        return cast(Dict[str, List[InternalOfficialDict]], response_data)
+
+    def get_match_events(self, match_id: int) -> List[InternalEventDict]:
+        """
+        Get events information for a specific match.
+
+        Args:
+            match_id: The ID of the match
+
+        Returns:
+            List[InternalEventDict]: Events information for the match
+
+        Raises:
+            InternalApiError: If the request fails
+        """
+        url = f"{self.BASE_URL}/MatchWebMetoder.aspx/GetMatchhandelselista"
+        payload = {"matchid": match_id}
+
+        response_data = self.api_request(url, payload)
+
+        if not isinstance(response_data, list):
+            error_msg = f"Invalid match events response: {response_data}"
+            self.logger.error(error_msg)
+            raise InternalApiError(error_msg)
+
+        return cast(List[InternalEventDict], response_data)
+
+    def get_team_players(self, team_id: int) -> InternalTeamPlayersResponse:
+        """
+        Get player information for a specific team.
+
+        Args:
+            team_id: The ID of the team
+
+        Returns:
+            InternalTeamPlayersResponse: Player information for the team
+
+        Raises:
+            InternalApiError: If the request fails
+        """
+        url = f"{self.BASE_URL}/MatchWebMetoder.aspx/GetMatchdeltagareListaForMatchlag"
+        payload = {"matchlagid": team_id}
+
+        response_data = self.api_request(url, payload)
+
+        # Handle different response formats
+        if isinstance(response_data, dict) and "spelare" in response_data:
+            return cast(InternalTeamPlayersResponse, response_data)
+        elif isinstance(response_data, list):
+            return cast(InternalTeamPlayersResponse, {"spelare": response_data})
+        else:
+            error_msg = f"Invalid team players response: {response_data}"
+            self.logger.error(error_msg)
+            raise InternalApiError(error_msg)
+
+    def get_team_officials(self, team_id: int) -> List[InternalOfficialDict]:
+        """
+        Get officials information for a specific team.
+
+        Args:
+            team_id: The ID of the team
+
+        Returns:
+            List[InternalOfficialDict]: Officials information for the team
+
+        Raises:
+            InternalApiError: If the request fails
+        """
+        url = f"{self.BASE_URL}/MatchWebMetoder.aspx/GetMatchlagledareListaForMatchlag"
+        payload = {"matchlagid": team_id}
+
+        response_data = self.api_request(url, payload)
+
+        if not isinstance(response_data, list):
+            error_msg = f"Invalid team officials response: {response_data}"
+            self.logger.error(error_msg)
+            raise InternalApiError(error_msg)
+
+        return cast(List[InternalOfficialDict], response_data)
+
+    def save_match_event(self, event_data: InternalEventDict) -> Dict[str, Any]:
+        """
+        Save a match event to the FOGIS API.
+
+        Args:
+            event_data: The event data to save
+
+        Returns:
+            Dict[str, Any]: The response from the API
+
+        Raises:
+            InternalApiError: If the request fails
+        """
+        url = f"{self.BASE_URL}/MatchWebMetoder.aspx/SparaMatchhandelse"
+
+        response_data = self.api_request(url, event_data)
+
+        if not isinstance(response_data, dict):
+            error_msg = f"Invalid save match event response: {response_data}"
+            self.logger.error(error_msg)
+            raise InternalApiError(error_msg)
+
+        return response_data
+
+    def save_match_result(self, result_data: InternalMatchResultDict) -> Dict[str, Any]:
+        """
+        Save match results to the FOGIS API.
+
+        Args:
+            result_data: The match result data to save
+
+        Returns:
+            Dict[str, Any]: The response from the API
+
+        Raises:
+            InternalApiError: If the request fails
+        """
+        url = f"{self.BASE_URL}/MatchWebMetoder.aspx/SparaMatchresultatLista"
+
+        response_data = self.api_request(url, result_data)
+
+        if not isinstance(response_data, dict):
+            error_msg = f"Invalid save match result response: {response_data}"
+            self.logger.error(error_msg)
+            raise InternalApiError(error_msg)
+
+        return response_data
+
+    def delete_match_event(self, event_id: int) -> Dict[str, Any]:
+        """
+        Delete a match event from the FOGIS API.
+
+        Args:
+            event_id: The ID of the event to delete
+
+        Returns:
+            Dict[str, Any]: The response from the API
+
+        Raises:
+            InternalApiError: If the request fails
+        """
+        url = f"{self.BASE_URL}/MatchWebMetoder.aspx/RaderaMatchhandelse"
+        payload = {"matchhandelseid": event_id}
+
+        response_data = self.api_request(url, payload)
+
+        # Handle different response formats
+        if response_data is None:
+            # Original API returns None on successful deletion
+            return {"success": True}
+        elif isinstance(response_data, dict):
+            return response_data
+        else:
+            error_msg = f"Invalid delete match event response: {response_data}"
+            self.logger.error(error_msg)
+            raise InternalApiError(error_msg)
+
+    def save_team_official_action(self, action_data: InternalOfficialActionDict) -> Dict[str, Any]:
+        """
+        Save a team official action to the FOGIS API.
+
+        Args:
+            action_data: The team official action data to save
+
+        Returns:
+            Dict[str, Any]: The response from the API
+
+        Raises:
+            InternalApiError: If the request fails
+        """
+        url = f"{self.BASE_URL}/MatchWebMetoder.aspx/SparaMatchlagledare"
+
+        response_data = self.api_request(url, action_data)
+
+        if not isinstance(response_data, dict):
+            error_msg = f"Invalid save team official action response: {response_data}"
+            self.logger.error(error_msg)
+            raise InternalApiError(error_msg)
+
+        return response_data
+
+    def clear_match_events(self, match_id: int) -> Dict[str, bool]:
+        """
+        Clear all events for a match.
+
+        Args:
+            match_id: The ID of the match
+
+        Returns:
+            Dict[str, bool]: The response from the API
+
+        Raises:
+            InternalApiError: If the request fails
+        """
+        url = f"{self.BASE_URL}/MatchWebMetoder.aspx/ClearMatchEvents"
+        payload = {"matchid": match_id}
+
+        response_data = self.api_request(url, payload)
+
+        if not isinstance(response_data, dict):
+            error_msg = f"Invalid clear match events response: {response_data}"
+            self.logger.error(error_msg)
+            raise InternalApiError(error_msg)
+
+        return cast(Dict[str, bool], response_data)
+
+    def get_match_result(self, match_id: int) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
+        """
+        Get the match results for a given match ID.
+
+        Args:
+            match_id: The ID of the match
+
+        Returns:
+            Union[Dict[str, Any], List[Dict[str, Any]]]: The match results
+
+        Raises:
+            InternalApiError: If the request fails
+        """
+        url = f"{self.BASE_URL}/MatchWebMetoder.aspx/GetMatchresultatlista"
+        payload = {"matchid": match_id}
+
+        response_data = self.api_request(url, payload)
+
+        if not isinstance(response_data, (dict, list)):
+            error_msg = f"Invalid match result response: {response_data}"
+            self.logger.error(error_msg)
+            raise InternalApiError(error_msg)
+
+        return response_data

--- a/fogis_api_client/internal/api_contracts.py
+++ b/fogis_api_client/internal/api_contracts.py
@@ -1,0 +1,413 @@
+"""
+API contract definitions for FOGIS API client.
+
+This module contains JSON Schema definitions for the API contracts that must be
+maintained when interacting with the FOGIS API. These schemas define the expected
+structure of data sent to and received from the API.
+
+The schemas are used for:
+1. Validating request payloads before sending to the API
+2. Validating response data from the API
+3. Testing API interactions to ensure contract compliance
+4. Documenting the required data structures
+"""
+import logging
+import re
+from typing import Any, Dict, Optional
+
+import jsonschema
+from jsonschema import ValidationError
+
+# Configure logging
+logger = logging.getLogger(__name__)
+
+
+class ValidationConfig:
+    """
+    Configuration options for API validation.
+
+    Attributes:
+        enable_validation (bool): Whether to enable validation (default: True)
+        strict_mode (bool): Whether to raise exceptions on validation failure (default: True)
+        log_validation_success (bool): Whether to log successful validations (default: True)
+    """
+
+    enable_validation = True
+    strict_mode = True
+    log_validation_success = True
+
+
+# Schema for match result reporting (nested format)
+MATCH_RESULT_NESTED_SCHEMA = {
+    "type": "object",
+    "required": ["matchresultatListaJSON"],
+    "properties": {
+        "matchresultatListaJSON": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "required": ["matchid", "matchresultattypid", "matchlag1mal", "matchlag2mal", "wo", "ow", "ww"],
+                "properties": {
+                    "matchid": {"type": "integer"},
+                    "matchresultattypid": {"type": "integer", "enum": [1, 2]},  # 1=fulltime, 2=halftime
+                    "matchlag1mal": {"type": "integer", "minimum": 0},
+                    "matchlag2mal": {"type": "integer", "minimum": 0},
+                    "wo": {"type": "boolean"},
+                    "ow": {"type": "boolean"},
+                    "ww": {"type": "boolean"},
+                },
+                "additionalProperties": False,
+            },
+        }
+    },
+    "additionalProperties": False,
+}
+
+# Schema for match result reporting (flat format)
+MATCH_RESULT_FLAT_SCHEMA = {
+    "type": "object",
+    "required": ["matchid", "hemmamal", "bortamal"],
+    "properties": {
+        "matchid": {"type": "integer"},
+        "hemmamal": {"type": "integer", "minimum": 0},
+        "bortamal": {"type": "integer", "minimum": 0},
+        "halvtidHemmamal": {"type": "integer", "minimum": 0},
+        "halvtidBortamal": {"type": "integer", "minimum": 0},
+    },
+    "additionalProperties": False,
+}
+
+# Schema for match event reporting
+MATCH_EVENT_SCHEMA = {
+    "type": "object",
+    "required": ["matchid", "period"],
+    "anyOf": [
+        {"required": ["matchhandelsetypid", "matchminut", "matchlagid"]},
+        {"required": ["handelsekod", "minut", "lagid"]}
+    ],
+    "properties": {
+        "matchid": {"type": "integer"},
+        "matchhandelseid": {"type": "integer"},
+        # Original property names
+        "handelsekod": {"type": "integer"},
+        "handelsetyp": {"type": "string"},
+        "minut": {"type": "integer", "minimum": 0},
+        "lagid": {"type": "integer"},
+        "lag": {"type": "string"},
+        "personid": {"type": ["integer", "null"]},
+        "spelare": {"type": ["string", "null"]},
+        "resultatHemma": {"type": ["integer", "null"], "minimum": 0},
+        "resultatBorta": {"type": ["integer", "null"], "minimum": 0},
+        # New property names
+        "matchhandelsetypid": {"type": "integer"},
+        "matchhandelsetypnamn": {"type": "string"},
+        "matchminut": {"type": "integer", "minimum": 0},
+        "matchlagid": {"type": "integer"},
+        "matchlagnamn": {"type": "string"},
+        "spelareid": {"type": ["integer", "null"]},
+        "spelarenamn": {"type": ["string", "null"]},
+        "hemmamal": {"type": ["integer", "null"], "minimum": 0},
+        "bortamal": {"type": ["integer", "null"], "minimum": 0},
+        # Common properties
+        "assisterande": {"type": ["string", "null"]},
+        "assisterandeid": {"type": ["integer", "null"]},
+        "period": {"type": "integer", "minimum": 1},
+        "mal": {"type": ["boolean", "null"]},
+        "strafflage": {"type": ["string", "null"]},
+        "straffriktning": {"type": ["string", "null"]},
+        "straffresultat": {"type": ["string", "null"]},
+    },
+    "additionalProperties": False,
+}
+
+# Schema for match event deletion
+MATCH_EVENT_DELETE_SCHEMA = {
+    "type": "object",
+    "required": ["matchhandelseid"],
+    "properties": {"matchhandelseid": {"type": "integer"}},
+    "additionalProperties": False,
+}
+
+# Schema for marking match reporting as finished
+MARK_REPORTING_FINISHED_SCHEMA = {
+    "type": "object",
+    "required": ["matchid"],
+    "properties": {"matchid": {"type": "integer"}},
+    "additionalProperties": False,
+}
+
+# Schema for team official action reporting
+TEAM_OFFICIAL_ACTION_SCHEMA = {
+    "type": "object",
+    "required": ["matchid", "matchlagledaretypid"],
+    "anyOf": [
+        {"required": ["matchlagid", "matchlagledareid"]},
+        {"required": ["lagid", "personid"]}
+    ],
+    "properties": {
+        "matchid": {"type": "integer"},
+        # Original property names
+        "lagid": {"type": "integer"},
+        "personid": {"type": "integer"},
+        "minut": {"type": ["integer", "null"], "minimum": 0},
+        # New property names
+        "matchlagid": {"type": "integer"},
+        "matchlagledareid": {"type": "integer"},
+        "matchminut": {"type": ["integer", "null"], "minimum": 0},
+        # Common properties
+        "matchlagledaretypid": {"type": "integer"},
+    },
+    "additionalProperties": False,
+}
+
+# Schema for match participant update
+MATCH_PARTICIPANT_SCHEMA = {
+    "type": "object",
+    "required": ["matchdeltagareid", "trojnummer", "lagdelid"],
+    "properties": {
+        "matchdeltagareid": {"type": "integer"},
+        "trojnummer": {"type": "integer"},
+        "lagdelid": {"type": "integer"},
+        "lagkapten": {"type": "boolean"},
+        "ersattare": {"type": "boolean"},
+        "positionsnummerhv": {"type": "integer"},
+        "arSpelandeLedare": {"type": "boolean"},
+        "ansvarig": {"type": "boolean"},
+    },
+    "additionalProperties": False,
+}
+
+# Schema for match list filter
+MATCH_LIST_FILTER_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "filter": {
+            "type": "object",
+            "properties": {
+                "datumFran": {"type": "string", "format": "date"},
+                "datumTill": {"type": "string", "format": "date"},
+                "datumTyp": {"type": "integer"},
+                "typ": {"type": "string"},
+                "status": {"type": "array", "items": {"type": "string"}},
+                "alderskategori": {"type": "array", "items": {"type": "integer"}},
+                "kon": {"type": "array", "items": {"type": "integer"}},
+                "sparadDatum": {"type": "string", "format": "date"},
+            },
+        }
+    },
+    "required": ["filter"],
+    "additionalProperties": False,
+}
+
+# Schema for match fetch
+MATCH_FETCH_SCHEMA = {
+    "type": "object",
+    "required": ["matchid"],
+    "properties": {"matchid": {"type": "integer"}},
+    "additionalProperties": False,
+}
+
+# Dictionary mapping API endpoints to their request schemas
+REQUEST_SCHEMAS = {
+    # Match result endpoints
+    "/MatchWebMetoder.aspx/SparaMatchresultatLista": MATCH_RESULT_NESTED_SCHEMA,
+    # Match event endpoints
+    "/MatchWebMetoder.aspx/SparaMatchhandelse": MATCH_EVENT_SCHEMA,
+    "/MatchWebMetoder.aspx/RaderaMatchhandelse": MATCH_EVENT_DELETE_SCHEMA,
+    # Match reporting endpoints
+    "/MatchWebMetoder.aspx/SparaMatchGodkannDomarrapport": MARK_REPORTING_FINISHED_SCHEMA,
+    # Team official action endpoints
+    "/MatchWebMetoder.aspx/SparaMatchlagledare": TEAM_OFFICIAL_ACTION_SCHEMA,
+    # Match participant endpoints
+    "/MatchWebMetoder.aspx/SparaMatchdeltagare": MATCH_PARTICIPANT_SCHEMA,
+    # Match list endpoints
+    "/MatchWebMetoder.aspx/GetMatcherAttRapportera": MATCH_LIST_FILTER_SCHEMA,
+    # Match fetch endpoints
+    "/MatchWebMetoder.aspx/GetMatch": MATCH_FETCH_SCHEMA,
+    "/MatchWebMetoder.aspx/GetMatchdeltagareLista": MATCH_FETCH_SCHEMA,
+    "/MatchWebMetoder.aspx/GetMatchfunktionarerLista": MATCH_FETCH_SCHEMA,
+    "/MatchWebMetoder.aspx/GetMatchhandelselista": MATCH_FETCH_SCHEMA,
+    "/MatchWebMetoder.aspx/GetMatchresultatlista": MATCH_FETCH_SCHEMA,
+}
+
+# Dictionary mapping API endpoints to their response schemas
+# Note: These are minimal schemas that only validate the structure, not the content
+RESPONSE_SCHEMAS = {
+    # These would be defined similarly to REQUEST_SCHEMAS
+    # For now, we'll focus on request validation
+}
+
+
+def extract_endpoint_from_url(url: str) -> str:
+    """
+    Extracts the endpoint path from a full URL.
+
+    Args:
+        url: The full URL (e.g., 'https://fogis.svenskfotboll.se/MatchWebMetoder.aspx/SparaMatchresultatLista')
+
+    Returns:
+        str: The endpoint path (e.g., '/MatchWebMetoder.aspx/SparaMatchresultatLista')
+    """
+    # Use regex to extract the endpoint path
+    match = re.search(r"(/[^/]+\.aspx/[^/]+)$", url)
+    if match:
+        return match.group(1)
+
+    # Fallback: just return the URL as is
+    return url
+
+
+def validate_request(endpoint: str, payload: Dict[str, Any]) -> bool:
+    """
+    Validates a request payload against the schema for the given endpoint.
+
+    Args:
+        endpoint: The API endpoint path (e.g., '/MatchWebMetoder.aspx/SparaMatchresultatLista')
+        payload: The request payload to validate
+
+    Returns:
+        bool: True if the payload is valid, False otherwise
+
+    Raises:
+        ValidationError: If the payload does not match the schema and strict_mode is True
+        ValueError: If the endpoint does not have a defined schema and strict_mode is True
+    """
+    # Skip validation if disabled
+    if not ValidationConfig.enable_validation:
+        return True
+
+    # Check if schema exists for this endpoint
+    if endpoint not in REQUEST_SCHEMAS:
+        message = f"No schema defined for endpoint: {endpoint}"
+        logger.warning(message)
+        if ValidationConfig.strict_mode:
+            raise ValueError(message)
+        return False
+
+    schema = REQUEST_SCHEMAS[endpoint]
+
+    try:
+        jsonschema.validate(instance=payload, schema=schema)
+        if ValidationConfig.log_validation_success:
+            logger.debug(f"Payload for {endpoint} is valid")
+        return True
+    except ValidationError as e:
+        detailed_error = f"Payload validation failed for {endpoint}: {e}"
+        logger.error(detailed_error)
+        if ValidationConfig.strict_mode:
+            raise ValidationError(detailed_error) from e
+        return False
+
+
+def validate_response(endpoint: str, response_data: Dict[str, Any]) -> bool:
+    """
+    Validates a response from the API against the schema for the given endpoint.
+
+    Args:
+        endpoint: The API endpoint path
+        response_data: The response data to validate
+
+    Returns:
+        bool: True if the response is valid, False otherwise
+
+    Raises:
+        ValidationError: If the response does not match the schema and strict_mode is True
+        ValueError: If the endpoint does not have a defined schema and strict_mode is True
+    """
+    # Skip validation if disabled
+    if not ValidationConfig.enable_validation:
+        return True
+
+    # Check if schema exists for this endpoint
+    if endpoint not in RESPONSE_SCHEMAS:
+        message = f"No response schema defined for endpoint: {endpoint}"
+        logger.warning(message)
+        # We don't raise an error for missing response schemas, even in strict mode
+        return True
+
+    schema = RESPONSE_SCHEMAS[endpoint]
+
+    try:
+        jsonschema.validate(instance=response_data, schema=schema)
+        if ValidationConfig.log_validation_success:
+            logger.debug(f"Response for {endpoint} is valid")
+        return True
+    except ValidationError as e:
+        detailed_error = f"Response validation failed for {endpoint}: {e}"
+        logger.error(detailed_error)
+        if ValidationConfig.strict_mode:
+            raise ValidationError(detailed_error) from e
+        return False
+
+
+def convert_flat_to_nested_match_result(flat_data: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Converts a flat match result structure to the nested structure required by the API.
+
+    Args:
+        flat_data: The flat match result data with fields like 'hemmamal' and 'bortamal'
+
+    Returns:
+        Dict[str, Any]: The nested structure with 'matchresultatListaJSON' array
+
+    Raises:
+        ValueError: If required fields are missing
+    """
+    # Validate the flat data against the flat schema
+    try:
+        jsonschema.validate(instance=flat_data, schema=MATCH_RESULT_FLAT_SCHEMA)
+    except ValidationError as e:
+        raise ValueError(f"Invalid flat match result data: {e}")
+
+    # Extract fields from the flat data
+    match_id = flat_data["matchid"]
+    fulltime_home = flat_data["hemmamal"]
+    fulltime_away = flat_data["bortamal"]
+    halftime_home = flat_data.get("halvtidHemmamal", 0)
+    halftime_away = flat_data.get("halvtidBortamal", 0)
+
+    # Create the nested structure
+    nested_data = {
+        "matchresultatListaJSON": [
+            {
+                "matchid": match_id,
+                "matchresultattypid": 1,  # Full time
+                "matchlag1mal": fulltime_home,
+                "matchlag2mal": fulltime_away,
+                "wo": False,
+                "ow": False,
+                "ww": False,
+            },
+            {
+                "matchid": match_id,
+                "matchresultattypid": 2,  # Half-time
+                "matchlag1mal": halftime_home,
+                "matchlag2mal": halftime_away,
+                "wo": False,
+                "ow": False,
+                "ww": False,
+            },
+        ]
+    }
+
+    # Validate the nested data against the nested schema
+    try:
+        jsonschema.validate(instance=nested_data, schema=MATCH_RESULT_NESTED_SCHEMA)
+    except ValidationError as e:
+        raise ValueError(f"Generated nested match result data is invalid: {e}")
+
+    return nested_data
+
+
+def get_schema_for_endpoint(endpoint: str) -> Optional[Dict[str, Any]]:
+    """
+    Returns the request schema for the given endpoint.
+
+    Args:
+        endpoint: The API endpoint path
+
+    Returns:
+        Optional[Dict[str, Any]]: The schema for the endpoint, or None if not found
+    """
+    return REQUEST_SCHEMAS.get(endpoint)

--- a/fogis_api_client/internal/auth.py
+++ b/fogis_api_client/internal/auth.py
@@ -1,0 +1,79 @@
+"""
+Authentication module for the FOGIS API client.
+
+This module handles authentication with the FOGIS API server.
+"""
+import logging
+import re
+from typing import Dict, Optional, Tuple, cast
+
+import requests
+from bs4 import BeautifulSoup
+
+from fogis_api_client.internal.types import InternalCookieDict
+
+logger = logging.getLogger(__name__)
+
+
+def authenticate(session: requests.Session, username: str, password: str, base_url: str) -> InternalCookieDict:
+    """
+    Authenticate with the FOGIS API server.
+
+    Args:
+        session: The requests session to use for authentication
+        username: The username to authenticate with
+        password: The password to authenticate with
+        base_url: The base URL of the FOGIS API server
+
+    Returns:
+        InternalCookieDict: The session cookies for authentication
+
+    Raises:
+        requests.exceptions.RequestException: If the authentication request fails
+        ValueError: If the authentication fails due to invalid credentials
+    """
+    login_url = f"{base_url}/Login.aspx?ReturnUrl=%2fmdk%2f"
+    logger.debug(f"Authenticating with {login_url}")
+
+    # Get the login page to extract the request verification token
+    response = session.get(login_url)
+    response.raise_for_status()
+
+    # Parse the HTML to extract the form tokens
+    soup = BeautifulSoup(response.text, "html.parser")
+    viewstate_input = soup.find("input", {"name": "__VIEWSTATE"})
+    if not viewstate_input or not viewstate_input.get("value"):
+        logger.error("Failed to extract VIEWSTATE token from login page")
+        raise ValueError("Failed to extract VIEWSTATE token from login page")
+
+    token = viewstate_input["value"]
+
+    # Prepare the login payload
+    login_payload = {
+        "__VIEWSTATE": token,
+        "__EVENTVALIDATION": token,  # Using the same token for simplicity
+        "ctl00$MainContent$UserName": username,
+        "ctl00$MainContent$Password": password,
+        "ctl00$MainContent$LoginButton": "Logga in",
+    }
+
+    # Submit the login form
+    response = session.post(login_url, data=login_payload, allow_redirects=True)
+    response.raise_for_status()
+
+    # Check if login was successful
+    if "FogisMobilDomarKlient.ASPXAUTH" not in session.cookies:
+        logger.error("Authentication failed: Invalid credentials")
+        raise ValueError("Authentication failed: Invalid credentials")
+
+    # Extract the cookies
+    cookies = cast(
+        InternalCookieDict,
+        {
+            "FogisMobilDomarKlient.ASPXAUTH": session.cookies.get("FogisMobilDomarKlient.ASPXAUTH"),
+            "ASP.NET_SessionId": session.cookies.get("ASP.NET_SessionId"),
+        },
+    )
+
+    logger.debug("Authentication successful")
+    return cookies

--- a/fogis_api_client/internal/types.py
+++ b/fogis_api_client/internal/types.py
@@ -1,0 +1,134 @@
+"""
+Internal type definitions for FOGIS API client.
+
+This module contains TypedDict classes and other type definitions used by the internal API layer.
+These types represent the exact structure expected by the FOGIS API server.
+"""
+from typing import Any, Dict, List, Optional, TypedDict, Union
+
+
+class InternalMatchDict(TypedDict, total=False):
+    """Internal type definition for a match object returned by the API."""
+    matchid: int
+    matchnr: str
+    datum: str
+    tid: str
+    hemmalag: str
+    bortalag: str
+    hemmalagid: int
+    bortalagid: int
+    arena: str
+    status: str
+    domare: str
+    ad1: str
+    ad2: str
+    fjarde: str
+    matchtyp: str
+    tavling: str
+    grupp: str
+    hemmamal: Optional[int]
+    bortamal: Optional[int]
+    publik: Optional[int]
+    notering: Optional[str]
+    rapportstatus: str
+    matchstart: Optional[str]
+    halvtidHemmamal: Optional[int]
+    halvtidBortamal: Optional[int]
+
+
+class InternalMatchListResponse(TypedDict):
+    """Internal type definition for the response from the match list endpoint."""
+    matchlista: List[InternalMatchDict]
+
+
+class InternalPlayerDict(TypedDict, total=False):
+    """Internal type definition for a player object returned by the API."""
+    personid: int
+    fornamn: str
+    efternamn: str
+    smeknamn: Optional[str]
+    tshirt: Optional[str]
+    position: Optional[str]
+    positionid: Optional[int]
+    lagkapten: Optional[bool]
+    spelareid: Optional[int]
+    licensnr: Optional[str]
+
+
+class InternalTeamPlayersResponse(TypedDict):
+    """Internal type definition for the response from the team players endpoint."""
+    spelare: List[InternalPlayerDict]
+
+
+class InternalOfficialDict(TypedDict, total=False):
+    """Internal type definition for an official object returned by the API."""
+    personid: int
+    fornamn: str
+    efternamn: str
+    roll: str
+    rollid: int
+
+
+class InternalEventDict(TypedDict, total=False):
+    """Internal type definition for an event object returned by the API."""
+    matchhandelseid: int
+    matchid: int
+    matchhandelsetypid: int
+    matchhandelsetypnamn: str
+    matchminut: int
+    matchlagid: int
+    matchlagnamn: str
+    spelareid: Optional[int]
+    spelarenamn: Optional[str]
+    assisterande: Optional[str]
+    assisterandeid: Optional[int]
+    period: Optional[int]
+    mal: Optional[bool]
+    hemmamal: Optional[int]
+    bortamal: Optional[int]
+    strafflage: Optional[str]
+    straffriktning: Optional[str]
+    straffresultat: Optional[str]
+
+
+class InternalMatchResultItem(TypedDict):
+    """Internal type definition for a single match result item in the nested format."""
+    matchid: int
+    matchresultattypid: int  # 1=fulltime, 2=halftime
+    matchlag1mal: int
+    matchlag2mal: int
+    wo: bool
+    ow: bool
+    ww: bool
+
+
+class InternalMatchResultDict(TypedDict):
+    """Internal type definition for a match result object in the nested format."""
+    matchresultatListaJSON: List[InternalMatchResultItem]
+
+
+class InternalOfficialActionDict(TypedDict, total=False):
+    """Internal type definition for a team official action used in reporting."""
+    matchid: int
+    matchlagid: int
+    matchlagledareid: int
+    matchlagledaretypid: int
+    matchminut: Optional[int]
+
+
+class InternalMatchParticipantDict(TypedDict, total=False):
+    """Internal type definition for a match participant update used in reporting."""
+    matchdeltagareid: int
+    trojnummer: int
+    lagdelid: int
+    lagkapten: bool
+    ersattare: bool
+    positionsnummerhv: int
+    arSpelandeLedare: bool
+    ansvarig: bool
+
+
+class InternalCookieDict(TypedDict, total=False):
+    """Internal type definition for session cookies."""
+    FogisMobilDomarKlient_ASPXAUTH: str
+    ASP_NET_SessionId: str

--- a/fogis_api_client/public_api_client.py
+++ b/fogis_api_client/public_api_client.py
@@ -1,0 +1,787 @@
+"""
+Public API client for the FOGIS API.
+
+This module provides a client for interacting with the FOGIS API.
+It uses the internal API layer to communicate with the server,
+but presents a simpler, more user-friendly interface.
+"""
+import json
+import logging
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional, Union, cast
+
+import requests
+
+from fogis_api_client.internal.adapters import (
+    convert_event_to_internal,
+    convert_internal_to_event,
+    convert_internal_to_match,
+    convert_internal_to_match_result,
+    convert_internal_to_official,
+    convert_internal_to_player,
+    convert_match_participant_to_internal,
+    convert_match_result_to_internal,
+    convert_official_action_to_internal,
+)
+from fogis_api_client.internal.api_client import InternalApiClient, InternalApiError
+from fogis_api_client.internal.auth import authenticate
+from fogis_api_client.types import (
+    CookieDict,
+    EventDict,
+    MatchDict,
+    MatchListResponse,
+    MatchParticipantDict,
+    MatchResultDict,
+    OfficialActionDict,
+    OfficialDict,
+    PlayerDict,
+    TeamPlayersResponse,
+)
+
+
+class FogisApiError(Exception):
+    """Base exception for all FOGIS API errors."""
+
+    pass
+
+
+class FogisLoginError(FogisApiError):
+    """Exception raised when login fails."""
+
+    pass
+
+
+class FogisAPIRequestError(FogisApiError):
+    """Exception raised when an API request fails."""
+
+    pass
+
+
+class FogisDataError(FogisApiError):
+    """Exception raised when data validation fails."""
+
+    pass
+
+
+class PublicApiClient:
+    """
+    A client for interacting with the FOGIS API.
+
+    This client implements lazy login, meaning it will automatically authenticate
+    when making API requests if not already logged in. You can also explicitly call
+    login() if you want to pre-authenticate.
+
+    Attributes:
+        BASE_URL (str): The base URL for the FOGIS API
+        logger (logging.Logger): Logger instance for this class
+        username (Optional[str]): FOGIS username if provided
+        password (Optional[str]): FOGIS password if provided
+        session (requests.Session): HTTP session for making requests
+        cookies (Optional[CookieDict]): Session cookies for authentication
+        internal_client (InternalApiClient): Internal API client for server communication
+    """
+
+    BASE_URL: str = "https://fogis.svenskfotboll.se/mdk"
+    # For tests, this can be overridden with an environment variable
+    import os
+    if os.environ.get("FOGIS_API_BASE_URL"):
+        BASE_URL = os.environ.get("FOGIS_API_BASE_URL")
+    logger: logging.Logger = logging.getLogger("fogis_api_client.api")
+
+    def __init__(
+        self,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        cookies: Optional[CookieDict] = None,
+    ) -> None:
+        """
+        Initializes the PublicApiClient with either login credentials or session cookies.
+
+        There are two ways to authenticate:
+        1. Username and password: Authentication happens automatically on the first
+           API request (lazy login),
+           or you can call login() explicitly if needed.
+        2. Session cookies: Provide cookies obtained from a previous session or external source.
+
+        Args:
+            username: FOGIS username. Required if cookies are not provided.
+            password: FOGIS password. Required if cookies are not provided.
+            cookies: Session cookies for authentication.
+                If provided, username and password are not required.
+
+        Raises:
+            ValueError: If neither valid credentials nor cookies are provided
+        """
+        self.username: Optional[str] = username
+        self.password: Optional[str] = password
+        self.session: requests.Session = requests.Session()
+        self.cookies: Optional[CookieDict] = None
+
+        # Initialize the internal API client
+        self.internal_client = InternalApiClient(self.session)
+
+        # Set cookies if provided
+        if cookies:
+            self.logger.debug("Using provided cookies for authentication")
+            self.cookies = cookies
+            # Set cookies in the session
+            for key, value in cookies.items():
+                self.session.cookies.set(key, value)
+        elif not (username and password):
+            error_msg = "Either username and password or cookies must be provided"
+            self.logger.error(error_msg)
+            raise ValueError(error_msg)
+
+    def login(self) -> CookieDict:
+        """
+        Authenticate with the FOGIS API.
+
+        This method is called automatically when needed, but you can also call it
+        explicitly if you want to pre-authenticate.
+
+        Returns:
+            CookieDict: The session cookies for authentication
+
+        Raises:
+            FogisLoginError: If login fails
+        """
+        # If cookies are already set, return them without logging in again
+        if self.cookies:
+            self.logger.debug("Already authenticated, using existing cookies")
+            return self.cookies
+
+        # If no username/password provided, we can't log in
+        if not (self.username and self.password):
+            error_msg = "Login failed: No credentials provided and no cookies available"
+            self.logger.error(error_msg)
+            raise FogisLoginError(error_msg)
+
+        try:
+            # Authenticate with the FOGIS API
+            self.cookies = authenticate(
+                self.session, self.username, self.password, self.BASE_URL
+            )
+            return self.cookies
+        except (requests.exceptions.RequestException, ValueError) as e:
+            error_msg = f"Login failed: {e}"
+            self.logger.error(error_msg)
+            raise FogisLoginError(error_msg) from e
+
+    def fetch_matches_list_json(
+        self, filter_params: Optional[Dict[str, Any]] = None
+    ) -> MatchListResponse:
+        """
+        Fetch the list of matches for the logged-in referee.
+
+        Args:
+            filter_params: Filter parameters for the match list.
+                If None, default filter parameters will be used.
+
+        Returns:
+            MatchListResponse: The match list response
+
+        Raises:
+            FogisLoginError: If not logged in
+            FogisAPIRequestError: If there's an error with the API request
+            FogisDataError: If the response data is invalid
+        """
+        # Ensure we're logged in
+        if not self.cookies:
+            self.login()
+
+        # Use default filter parameters if none provided
+        if filter_params is None:
+            # Default to matches for the next 7 days
+            today = datetime.now().strftime("%Y-%m-%d")
+            next_week = (datetime.now() + timedelta(days=7)).strftime("%Y-%m-%d")
+            filter_params = {
+                "datumFran": today,
+                "datumTill": next_week,
+                "datumTyp": 1,  # Match date
+                "status": ["Ej rapporterad", "Påbörjad rapportering"],
+            }
+
+        try:
+            # Use the internal API client to fetch the match list
+            response_data = self.internal_client.get_matches_list(filter_params)
+
+            # Convert to the public format
+            return cast(MatchListResponse, response_data)
+        except InternalApiError as e:
+            error_msg = f"Failed to fetch match list: {e}"
+            self.logger.error(error_msg)
+            raise FogisAPIRequestError(error_msg) from e
+
+    def fetch_match_json(self, match_id: Union[int, str]) -> MatchDict:
+        """
+        Fetch detailed information for a specific match.
+
+        Args:
+            match_id: The ID of the match
+
+        Returns:
+            MatchDict: The match details
+
+        Raises:
+            FogisLoginError: If not logged in
+            FogisAPIRequestError: If there's an error with the API request
+            FogisDataError: If the response data is invalid
+        """
+        # Ensure we're logged in
+        if not self.cookies:
+            self.login()
+
+        # Convert match_id to int if it's a string
+        match_id_int = int(match_id) if isinstance(match_id, str) else match_id
+
+        try:
+            # Use the internal API client to fetch the match details
+            internal_match = self.internal_client.get_match(match_id_int)
+
+            # Convert to the public format
+            return convert_internal_to_match(internal_match)
+        except InternalApiError as e:
+            error_msg = f"Failed to fetch match details: {e}"
+            self.logger.error(error_msg)
+            raise FogisAPIRequestError(error_msg) from e
+
+    def fetch_match_players_json(self, match_id: Union[int, str]) -> Dict[str, List[PlayerDict]]:
+        """
+        Fetch player information for a specific match.
+
+        Args:
+            match_id: The ID of the match
+
+        Returns:
+            Dict[str, List[PlayerDict]]: Player information for the match
+
+        Raises:
+            FogisLoginError: If not logged in
+            FogisAPIRequestError: If there's an error with the API request
+            FogisDataError: If the response data is invalid
+        """
+        # Ensure we're logged in
+        if not self.cookies:
+            self.login()
+
+        # Convert match_id to int if it's a string
+        match_id_int = int(match_id) if isinstance(match_id, str) else match_id
+
+        try:
+            # Use the internal API client to fetch the match players
+            internal_players = self.internal_client.get_match_players(match_id_int)
+
+            # Convert to the public format
+            result: Dict[str, List[PlayerDict]] = {}
+            for key, players in internal_players.items():
+                result[key] = [convert_internal_to_player(player) for player in players]
+
+            return result
+        except InternalApiError as e:
+            error_msg = f"Failed to fetch match players: {e}"
+            self.logger.error(error_msg)
+            raise FogisAPIRequestError(error_msg) from e
+
+    def fetch_match_officials_json(self, match_id: Union[int, str]) -> Dict[str, List[OfficialDict]]:
+        """
+        Fetch officials information for a specific match.
+
+        Args:
+            match_id: The ID of the match
+
+        Returns:
+            Dict[str, List[OfficialDict]]: Officials information for the match
+
+        Raises:
+            FogisLoginError: If not logged in
+            FogisAPIRequestError: If there's an error with the API request
+            FogisDataError: If the response data is invalid
+        """
+        # Ensure we're logged in
+        if not self.cookies:
+            self.login()
+
+        # Convert match_id to int if it's a string
+        match_id_int = int(match_id) if isinstance(match_id, str) else match_id
+
+        try:
+            # Use the internal API client to fetch the match officials
+            internal_officials = self.internal_client.get_match_officials(match_id_int)
+
+            # Convert to the public format
+            result: Dict[str, List[OfficialDict]] = {}
+            for key, officials in internal_officials.items():
+                result[key] = [convert_internal_to_official(official) for official in officials]
+
+            return result
+        except InternalApiError as e:
+            error_msg = f"Failed to fetch match officials: {e}"
+            self.logger.error(error_msg)
+            raise FogisAPIRequestError(error_msg) from e
+
+    def fetch_match_events_json(self, match_id: Union[int, str]) -> List[EventDict]:
+        """
+        Fetch events information for a specific match.
+
+        Args:
+            match_id: The ID of the match
+
+        Returns:
+            List[EventDict]: Events information for the match
+
+        Raises:
+            FogisLoginError: If not logged in
+            FogisAPIRequestError: If there's an error with the API request
+            FogisDataError: If the response data is invalid
+        """
+        # Ensure we're logged in
+        if not self.cookies:
+            self.login()
+
+        # Convert match_id to int if it's a string
+        match_id_int = int(match_id) if isinstance(match_id, str) else match_id
+
+        try:
+            # Use the internal API client to fetch the match events
+            internal_events = self.internal_client.get_match_events(match_id_int)
+
+            # Convert to the public format
+            return [convert_internal_to_event(event) for event in internal_events]
+        except InternalApiError as e:
+            error_msg = f"Failed to fetch match events: {e}"
+            self.logger.error(error_msg)
+            raise FogisAPIRequestError(error_msg) from e
+
+    def fetch_team_players_json(self, team_id: Union[int, str]) -> TeamPlayersResponse:
+        """
+        Fetch player information for a specific team.
+
+        Args:
+            team_id: The ID of the team
+
+        Returns:
+            TeamPlayersResponse: Player information for the team
+
+        Raises:
+            FogisLoginError: If not logged in
+            FogisAPIRequestError: If there's an error with the API request
+            FogisDataError: If the response data is invalid
+        """
+        # Ensure we're logged in
+        if not self.cookies:
+            self.login()
+
+        # Convert team_id to int if it's a string
+        team_id_int = int(team_id) if isinstance(team_id, str) else team_id
+
+        try:
+            # Use the internal API client to fetch the team players
+            internal_players = self.internal_client.get_team_players(team_id_int)
+
+            # For now, just cast to the public format since they're the same
+            return cast(TeamPlayersResponse, internal_players)
+        except InternalApiError as e:
+            error_msg = f"Failed to fetch team players: {e}"
+            self.logger.error(error_msg)
+            raise FogisAPIRequestError(error_msg) from e
+
+    def report_match_event(self, event_data: EventDict) -> Dict[str, Any]:
+        """
+        Report a match event to the FOGIS API.
+
+        Args:
+            event_data: The event data to report
+
+        Returns:
+            Dict[str, Any]: The response from the API
+
+        Raises:
+            FogisLoginError: If not logged in
+            FogisAPIRequestError: If there's an error with the API request
+            FogisDataError: If the response data is invalid
+            ValueError: If required fields are missing
+        """
+        # Ensure we're logged in
+        if not self.cookies:
+            self.login()
+
+        # Validate required fields
+        required_fields = [
+            "matchid",
+            "matchhandelsetypid",
+            "matchminut",
+            "matchlagid",
+            "period"
+        ]
+        for field in required_fields:
+            if field not in event_data:
+                error_msg = f"Missing required field '{field}' in event data"
+                self.logger.error(error_msg)
+                raise ValueError(error_msg)
+
+        try:
+            # Convert to the internal format
+            internal_event = convert_event_to_internal(event_data)
+
+            # Use the internal API client to report the match event
+            response_data = self.internal_client.save_match_event(internal_event)
+
+            return response_data
+        except InternalApiError as e:
+            error_msg = f"Failed to report match event: {e}"
+            self.logger.error(error_msg)
+            raise FogisAPIRequestError(error_msg) from e
+
+    def fetch_match_result_json(self, match_id: Union[int, str]) -> Union[MatchResultDict, List[Dict[str, Any]]]:
+        """
+        Fetch the match results for a given match ID.
+
+        Args:
+            match_id: The ID of the match
+
+        Returns:
+            Union[MatchResultDict, List[Dict[str, Any]]]: The match results
+
+        Raises:
+            FogisLoginError: If not logged in
+            FogisAPIRequestError: If there's an error with the API request
+            FogisDataError: If the response data is invalid
+        """
+        # Ensure we're logged in
+        if not self.cookies:
+            self.login()
+
+        # Convert match_id to int if it's a string
+        match_id_int = int(match_id) if isinstance(match_id, str) else match_id
+
+        try:
+            # Use the internal API client to fetch the match result
+            internal_result = self.internal_client.get_match_result(match_id_int)
+
+            # Convert to the public format
+            return convert_internal_to_match_result(internal_result)
+        except InternalApiError as e:
+            error_msg = f"Failed to fetch match result: {e}"
+            self.logger.error(error_msg)
+            raise FogisAPIRequestError(error_msg) from e
+
+    def report_match_result(self, result_data: Union[MatchResultDict, Dict[str, Any]]) -> Dict[str, Any]:
+        """
+        Report match results to the FOGIS API.
+
+        Args:
+            result_data: The match result data to report.
+                Can be in either flat format (with hemmamal/bortamal) or
+                nested format (with matchresultatListaJSON).
+
+        Returns:
+            Dict[str, Any]: The response from the API
+
+        Raises:
+            FogisLoginError: If not logged in
+            FogisAPIRequestError: If there's an error with the API request
+            FogisDataError: If the response data is invalid
+            ValueError: If required fields are missing
+        """
+        # Ensure we're logged in
+        if not self.cookies:
+            self.login()
+
+        # Validate required fields for flat format
+        if "matchresultatListaJSON" not in result_data:
+            required_fields = ["matchid", "hemmamal", "bortamal"]
+            for field in required_fields:
+                if field not in result_data:
+                    error_msg = f"Missing required field '{field}' in result data"
+                    self.logger.error(error_msg)
+                    raise ValueError(error_msg)
+
+        try:
+            # Convert to the internal format
+            internal_result = convert_match_result_to_internal(result_data)
+
+            # Use the internal API client to report the match result
+            response_data = self.internal_client.save_match_result(internal_result)
+
+            return response_data
+        except InternalApiError as e:
+            error_msg = f"Failed to report match result: {e}"
+            self.logger.error(error_msg)
+            raise FogisAPIRequestError(error_msg) from e
+
+    def delete_match_event(self, event_id: Union[int, str]) -> Dict[str, Any]:
+        """
+        Delete a match event from the FOGIS API.
+
+        Args:
+            event_id: The ID of the event to delete
+
+        Returns:
+            Dict[str, Any]: The response from the API
+
+        Raises:
+            FogisLoginError: If not logged in
+            FogisAPIRequestError: If there's an error with the API request
+            FogisDataError: If the response data is invalid
+        """
+        # Ensure we're logged in
+        if not self.cookies:
+            self.login()
+
+        # Convert event_id to int if it's a string
+        event_id_int = int(event_id) if isinstance(event_id, str) else event_id
+
+        try:
+            # Use the internal API client to delete the match event
+            response_data = self.internal_client.delete_match_event(event_id_int)
+
+            return response_data
+        except InternalApiError as e:
+            error_msg = f"Failed to delete match event: {e}"
+            self.logger.error(error_msg)
+            raise FogisAPIRequestError(error_msg) from e
+
+    def report_team_official_action(self, action_data: OfficialActionDict) -> Dict[str, Any]:
+        """
+        Report a team official action to the FOGIS API.
+
+        Args:
+            action_data: The team official action data to report
+
+        Returns:
+            Dict[str, Any]: The response from the API
+
+        Raises:
+            FogisLoginError: If not logged in
+            FogisAPIRequestError: If there's an error with the API request
+            FogisDataError: If the response data is invalid
+            ValueError: If required fields are missing
+        """
+        # Ensure we're logged in
+        if not self.cookies:
+            self.login()
+
+        # Validate required fields
+        required_fields = ["matchid", "lagid", "personid", "matchlagledaretypid"]
+        for field in required_fields:
+            if field not in action_data:
+                error_msg = f"Missing required field '{field}' in action data"
+                self.logger.error(error_msg)
+                raise ValueError(error_msg)
+
+        try:
+            # Convert to the internal format
+            internal_action = convert_official_action_to_internal(action_data)
+
+            # Use the internal API client to report the team official action
+            response_data = self.internal_client.save_team_official_action(internal_action)
+
+            return response_data
+        except InternalApiError as e:
+            error_msg = f"Failed to report team official action: {e}"
+            self.logger.error(error_msg)
+            raise FogisAPIRequestError(error_msg) from e
+
+    def fetch_team_officials_json(self, team_id: Union[int, str]) -> List[OfficialDict]:
+        """
+        Fetch officials information for a specific team.
+
+        Args:
+            team_id: The ID of the team
+
+        Returns:
+            List[OfficialDict]: Officials information for the team
+
+        Raises:
+            FogisLoginError: If not logged in
+            FogisAPIRequestError: If there's an error with the API request
+            FogisDataError: If the response data is invalid
+        """
+        # Ensure we're logged in
+        if not self.cookies:
+            self.login()
+
+        # Convert team_id to int if it's a string
+        team_id_int = int(team_id) if isinstance(team_id, str) else team_id
+
+        try:
+            # Use the internal API client to fetch the team officials
+            internal_officials = self.internal_client.get_team_officials(team_id_int)
+
+            # Convert to the public format
+            return [convert_internal_to_official(official) for official in internal_officials]
+        except InternalApiError as e:
+            error_msg = f"Failed to fetch team officials: {e}"
+            self.logger.error(error_msg)
+            raise FogisAPIRequestError(error_msg) from e
+
+    def save_match_participant(self, participant_data: MatchParticipantDict) -> Dict[str, Any]:
+        """
+        Save a match participant to the FOGIS API.
+
+        Args:
+            participant_data: The match participant data to save
+
+        Returns:
+            Dict[str, Any]: The response from the API
+
+        Raises:
+            FogisLoginError: If not logged in
+            FogisAPIRequestError: If there's an error with the API request
+            FogisDataError: If the response data is invalid
+            ValueError: If required fields are missing
+        """
+        # Ensure we're logged in
+        if not self.cookies:
+            self.login()
+
+        # Validate required fields
+        required_fields = ["matchdeltagareid", "trojnummer", "lagdelid"]
+        for field in required_fields:
+            if field not in participant_data:
+                error_msg = f"Missing required field '{field}' in participant data"
+                self.logger.error(error_msg)
+                raise ValueError(error_msg)
+
+        try:
+            # Convert to the internal format
+            internal_participant = convert_match_participant_to_internal(participant_data)
+
+            # Use the internal API client to save the match participant
+            url = f"{self.BASE_URL}/MatchWebMetoder.aspx/SparaMatchdeltagare"
+            headers = {
+                "Content-Type": "application/json; charset=utf-8",
+                "Accept": "application/json, text/javascript, */*; q=0.01",
+                "X-Requested-With": "XMLHttpRequest",
+            }
+
+            response = self.session.post(url, json=internal_participant, headers=headers)
+            response.raise_for_status()
+
+            # Parse the JSON response
+            response_data = response.json()
+
+            # Extract the 'd' field if it exists
+            if isinstance(response_data, dict) and "d" in response_data:
+                try:
+                    return json.loads(response_data["d"])
+                except (json.JSONDecodeError, TypeError):
+                    return response_data["d"]
+
+            return response_data
+        except requests.exceptions.RequestException as e:
+            error_msg = f"Failed to save match participant: {e}"
+            self.logger.error(error_msg)
+            raise FogisAPIRequestError(error_msg) from e
+
+    def clear_match_events(self, match_id: Union[int, str]) -> Dict[str, bool]:
+        """
+        Clear all events for a match.
+
+        Args:
+            match_id: The ID of the match
+
+        Returns:
+            Dict[str, bool]: The response from the API
+
+        Raises:
+            FogisLoginError: If not logged in
+            FogisAPIRequestError: If there's an error with the API request
+            FogisDataError: If the response data is invalid
+        """
+        # Ensure we're logged in
+        if not self.cookies:
+            self.login()
+
+        # Convert match_id to int if it's a string
+        match_id_int = int(match_id) if isinstance(match_id, str) else match_id
+
+        try:
+            # Use the internal API client to clear the match events
+            return self.internal_client.clear_match_events(match_id_int)
+        except InternalApiError as e:
+            error_msg = f"Failed to clear match events: {e}"
+            self.logger.error(error_msg)
+            raise FogisAPIRequestError(error_msg) from e
+
+    def get_cookies(self) -> Optional[CookieDict]:
+        """
+        Get the current session cookies.
+
+        Returns:
+            Optional[CookieDict]: The current session cookies, or None if not logged in
+        """
+        if self.cookies:
+            self.logger.debug("Returning current session cookies")
+        else:
+            self.logger.debug("No cookies available to return")
+        return self.cookies
+
+    def hello_world(self) -> str:
+        """
+        Simple test method.
+
+        Returns:
+            str: A greeting message
+        """
+        self.logger.debug("Hello world method called")
+        return "Hello, brave new world!"
+
+    def mark_reporting_finished(self, match_id: Union[int, str]) -> Dict[str, bool]:
+        """
+        Mark match reporting as finished.
+
+        Args:
+            match_id: The ID of the match
+
+        Returns:
+            Dict[str, bool]: The response from the FOGIS API, typically containing a success status
+
+        Raises:
+            FogisLoginError: If not logged in
+            FogisAPIRequestError: If there's an error with the API request
+            FogisDataError: If the response data is invalid or not a dictionary
+            ValueError: If match_id is empty or invalid
+        """
+        # Validate match_id
+        if not match_id:
+            error_msg = "match_id cannot be empty"
+            self.logger.error(error_msg)
+            raise ValueError(error_msg)
+
+        # Ensure we're logged in
+        if not self.cookies:
+            self.login()
+
+        # Convert match_id to int if it's a string
+        match_id_int = int(match_id) if isinstance(match_id, str) else match_id
+
+        try:
+            # Use the internal API client to mark reporting as finished
+            url = f"{self.BASE_URL}/MatchWebMetoder.aspx/SparaMatchGodkannDomarrapport"
+            payload = {"matchid": match_id_int}
+
+            # For now, use the _api_request method directly since we don't have an internal method for this
+            response_data = self.session.post(url, json=payload, headers={
+                "Content-Type": "application/json; charset=utf-8",
+                "Accept": "application/json, text/javascript, */*; q=0.01",
+                "X-Requested-With": "XMLHttpRequest",
+            })
+            response_data.raise_for_status()
+
+            # Parse the JSON response
+            response_json = response_data.json()
+
+            # Extract the 'd' field if it exists
+            if isinstance(response_json, dict) and "d" in response_json:
+                try:
+                    result = json.loads(response_json["d"])
+                    return cast(Dict[str, bool], result)
+                except (json.JSONDecodeError, TypeError):
+                    return {"success": True}
+
+            return {"success": True}
+        except requests.exceptions.RequestException as e:
+            error_msg = f"Failed to mark reporting as finished: {e}"
+            self.logger.error(error_msg)
+            raise FogisAPIRequestError(error_msg) from e


### PR DESCRIPTION
This PR applies the same changes from PR #188 to the main branch to make the fix immediately available in production.

## Changes
- Updated InternalEventDict in types.py to keep original property names
- Updated InternalOfficialActionDict in types.py to use matchlagid, matchlagledareid, matchminut
- Modified adapters.py to handle property name mapping correctly
- Updated api_contracts.py to accept both old and new property names
- Updated public_api_client.py to validate using the original property names
- Updated changelog.md with a new version entry (0.4.3)

Fixes #187