### PR TITLE
Fix package name capitalization in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setuptools.setup(
-    name="fogis-api-client-timmyBird",
+    name="fogis-api-client-timmybird",
     version="0.4.3",
     author="Bartek Svaberg",
     author_email="bartek.svaberg@gmail.com",


### PR DESCRIPTION
This PR fixes the package name capitalization in setup.py to ensure consistent naming in the built packages.