### PR TITLE
Update publish-to-pypi.yml workflow to explicitly use main branch and add debugging

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        ref: main
+        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
@@ -17,6 +20,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install build twine
+    - name: Debug setup.py
+      run: |
+        echo "Current setup.py content:"
+        cat setup.py
+        grep -n "version" setup.py
     - name: Build package
       run: python -m build
     - name: Build and publish


### PR DESCRIPTION
This PR updates the publish-to-pypi.yml workflow to explicitly use the main branch and adds debugging output to help troubleshoot the PyPI publishing issue.