### PR TITLE
Bump version to 0.4.4

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.4.4] - 2025-05-20
+
+### Fixed
+- Fixed package name capitalization in setup.py (correct to timmyBird)
+- Updated publish-to-pypi.yml workflow to explicitly set version from release tag
+
 ## [0.4.3] - 2025-05-20
 
 ### Fixed

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="fogis-api-client-timmyBird",
-    version="0.4.3",
+    version="0.4.4",
     author="Bartek Svaberg",
     author_email="bartek.svaberg@gmail.com",
     description="A Python client for the FOGIS API (Svensk Fotboll)",


### PR DESCRIPTION
This PR bumps the version to 0.4.4 to avoid conflicts with the existing 0.4.2 and 0.4.3 versions on PyPI. This should fix the PyPI publishing issue.