### PR TITLE
Add mock server as a dev dependency for easier local testing

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -54,9 +54,11 @@ We provide a Docker-based development environment that makes it easy to develop 
 
 ### Running Integration Tests
 
-To run the integration tests:
+There are two ways to run the integration tests:
 
-```
+#### Using Docker (Recommended for CI/CD)
+
+```bash
 ./run_integration_tests.sh
 ```
 
@@ -64,6 +66,25 @@ This will:
 - Start the development environment if it's not already running
 - Run the integration tests against the API
 - Show the test results
+
+#### Using Local Mock Server (Recommended for Development)
+
+1. Install the mock server dependencies:
+   ```bash
+   pip install -e ".[dev,mock-server]"
+   ```
+
+2. Start the mock server in a separate terminal:
+   ```bash
+   python scripts/run_mock_server.py
+   ```
+
+3. Run the integration tests:
+   ```bash
+   python -m pytest integration_tests
+   ```
+
+The mock server provides a simulated FOGIS API environment for testing without requiring Docker or real credentials.
 
 ### Development Workflow
 

--- a/README.md
+++ b/README.md
@@ -135,9 +135,41 @@ This project includes comprehensive integration tests to verify that the client 
 - **No Real Credentials**: Test without needing actual FOGIS credentials
 - **Fast and Reliable**: Tests run quickly and consistently in any environment
 
+### Mock Server
+
+The mock server simulates the FOGIS API for testing and development. You can use it in two ways:
+
+#### Using the CLI Tool
+
+```bash
+# Install the mock server dependencies
+pip install -e ".[mock-server]"
+
+# Start the mock server
+python -m fogis_api_client.cli.mock_server
+
+# With custom host and port
+python -m fogis_api_client.cli.mock_server --host 0.0.0.0 --port 5001
+```
+
+#### Using the Standalone Script
+
+```bash
+# Start the mock server
+python scripts/run_mock_server.py
+```
+
+The mock server provides a simulated FOGIS API environment that you can use for:
+- Running integration tests without Docker
+- Developing and testing new features
+- Debugging API interactions
+- Testing client applications without real credentials
+
 ### Running Integration Tests
 
-The easiest way to run integration tests is using the provided script:
+There are multiple ways to run integration tests:
+
+#### Using Docker (Recommended for CI/CD)
 
 ```bash
 ./run_integration_tests.sh
@@ -147,6 +179,16 @@ This script will:
 1. Start a Docker environment with the mock FOGIS server
 2. Run all integration tests against the mock server
 3. Report the results and clean up the environment
+
+#### Using Local Mock Server (Recommended for Development)
+
+```bash
+# In terminal 1: Start the mock server
+python -m fogis_api_client.cli.mock_server
+
+# In terminal 2: Run the tests
+python -m pytest integration_tests
+```
 
 You can also run specific test files directly:
 

--- a/fogis_api_client/cli/README.md
+++ b/fogis_api_client/cli/README.md
@@ -1,0 +1,41 @@
+# FOGIS API Client CLI Tools
+
+This directory contains command-line interface (CLI) tools for the FOGIS API client.
+
+## Available Tools
+
+### Mock Server
+
+The mock server CLI tool provides a convenient way to start and manage the mock FOGIS API server for development and testing.
+
+#### Usage
+
+```bash
+# Start the mock server with default settings
+python -m fogis_api_client.cli.mock_server
+
+# Specify host and port
+python -m fogis_api_client.cli.mock_server --host 0.0.0.0 --port 5001
+
+# Show help
+python -m fogis_api_client.cli.mock_server --help
+```
+
+#### Options
+
+- `--host HOST`: Host to bind the server to (default: localhost)
+- `--port PORT`: Port to run the server on (default: 5001)
+
+#### Programmatic Usage
+
+You can also use the mock server CLI tool programmatically:
+
+```python
+from fogis_api_client.cli.mock_server import run_server
+
+# Start the mock server with default settings
+run_server()
+
+# Specify host and port
+run_server(host="0.0.0.0", port=5001)
+```

--- a/fogis_api_client/cli/__init__.py
+++ b/fogis_api_client/cli/__init__.py
@@ -1,0 +1,1 @@
+"""CLI tools for the FOGIS API client."""

--- a/fogis_api_client/cli/mock_server.py
+++ b/fogis_api_client/cli/mock_server.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""
+CLI tool for running the mock FOGIS API server.
+
+This module provides a command-line interface for starting and managing
+the mock FOGIS API server for development and testing.
+
+Usage:
+    python -m fogis_api_client.cli.mock_server [--host HOST] [--port PORT]
+"""
+
+import argparse
+import logging
+import os
+import sys
+from typing import Optional
+
+# Add the project root to the Python path if needed
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+# Import the mock server
+from integration_tests.mock_fogis_server import MockFogisServer
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Run the mock FOGIS API server")
+    parser.add_argument(
+        "--host", default="localhost", help="Host to bind the server to (default: localhost)"
+    )
+    parser.add_argument(
+        "--port", type=int, default=5001, help="Port to run the server on (default: 5001)"
+    )
+    return parser.parse_args()
+
+
+def run_server(host: Optional[str] = None, port: Optional[int] = None):
+    """
+    Run the mock FOGIS API server.
+
+    Args:
+        host: Host to bind the server to (default: localhost)
+        port: Port to run the server on (default: 5001)
+    """
+    # Use command line arguments if provided, otherwise use defaults
+    args = parse_args()
+    host = host or args.host
+    port = port or args.port
+
+    logger.info(f"Starting mock FOGIS server on {host}:{port}")
+    
+    # Create and run the server
+    server = MockFogisServer(host=host, port=port)
+    server.run()
+
+
+def main():
+    """Run the mock server from the command line."""
+    run_server()
+
+
+if __name__ == "__main__":
+    main()

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -86,14 +86,42 @@ This script will:
 
 ### Running Tests Locally
 
-To run the integration tests without Docker:
+There are two ways to run the integration tests locally:
+
+#### Using the Pytest Fixture (Automatic Mock Server)
+
+The simplest way is to let the pytest fixture start the mock server automatically:
 
 ```bash
 python -m pytest integration_tests/test_with_mock_server.py -v
 python -m pytest integration_tests/test_match_result_reporting.py -v
 ```
 
-Note: When running locally, you'll need to start the mock server manually or use the pytest fixtures to start it automatically.
+This approach uses the `mock_fogis_server` fixture in `conftest.py` to start the mock server in a separate thread during test execution.
+
+#### Using the Standalone Mock Server (Recommended for Development)
+
+For development and debugging, it's often better to run the mock server separately:
+
+1. Install the mock server dependencies:
+   ```bash
+   pip install -e ".[dev,mock-server]"
+   ```
+
+2. Start the mock server in a separate terminal:
+   ```bash
+   python scripts/run_mock_server.py
+   ```
+
+3. Run the integration tests:
+   ```bash
+   python -m pytest integration_tests
+   ```
+
+Running the mock server separately allows you to:
+- Inspect the server logs in real-time
+- Keep the server running between test runs
+- Test individual API endpoints manually using tools like curl or Postman
 
 ## Request Validation
 

--- a/scripts/run_mock_server.py
+++ b/scripts/run_mock_server.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""
+Script to run the mock FOGIS API server locally.
+
+This script provides a convenient way to start the mock server for local development
+and testing without requiring Docker.
+
+Usage:
+    python scripts/run_mock_server.py [--host HOST] [--port PORT]
+
+Options:
+    --host HOST     Host to bind the server to (default: localhost)
+    --port PORT     Port to run the server on (default: 5001)
+"""
+
+import argparse
+import logging
+import os
+import sys
+
+# Add the project root to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Import the mock server
+from integration_tests.mock_fogis_server import MockFogisServer
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Run the mock FOGIS API server")
+    parser.add_argument(
+        "--host", default="localhost", help="Host to bind the server to (default: localhost)"
+    )
+    parser.add_argument(
+        "--port", type=int, default=5001, help="Port to run the server on (default: 5001)"
+    )
+    return parser.parse_args()
+
+
+def main():
+    """Run the mock server."""
+    args = parse_args()
+    logger.info(f"Starting mock FOGIS server on {args.host}:{args.port}")
+    
+    # Create and run the server
+    server = MockFogisServer(host=args.host, port=args.port)
+    server.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,12 @@ setuptools.setup(
             "flake8",
             "flask-cors",
         ],
+        "mock-server": [
+            "flask",
+            "flask-swagger-ui",
+            "apispec>=6.0.0",
+            "marshmallow>=3.26.0",
+        ],
     },
     include_package_data=True,
 )


### PR DESCRIPTION
## Description
This PR adds the mock server as a development dependency to make it easier for developers to run integration tests locally without requiring Docker.

## Changes
- Add a `mock-server` extra to setup.py with required dependencies
- Create a standalone script in scripts/run_mock_server.py
- Create a CLI tool in fogis_api_client/cli/mock_server.py
- Update README.md, README.dev.md, and integration_tests/README.md with instructions

## Benefits
- Easier local development without Docker
- Faster feedback loop for integration tests
- Better developer experience
- More accessible testing for new contributors

## Testing
- Verified that the standalone script works
- Verified that the CLI tool works
- Verified that integration tests pass with the local mock server

Fixes #204

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author