### PR TITLE
Version bump to 0.5.3 - Enable PyPI and GHCR release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 # Define setup kwargs for workflow compatibility
 setup_kwargs = {
     "name": "fogis-api-client-timmyBird",
-    "version": "0.5.2",
+    "version": "0.5.3",
     "author": "Bartek Svaberg",
     "author_email": "bartek.svaberg@gmail.com",
     "description": "A Python client for the FOGIS API (Svensk Fotboll)",


### PR DESCRIPTION
## Summary

This PR bumps the version from 0.5.2 to 0.5.3 to enable a clean release to both PyPI and GHCR.

## Background

The previous PR #236 successfully fixed the setup.py verification issue and workflow problems, but the PyPI release failed because version 0.5.2 already exists on PyPI (released May 26th, 2025). PyPI doesn't allow overwriting existing versions.

## Changes

- **Version bump**: Updated setup.py version from "0.5.2" to "0.5.3"
- **No functional changes**: This is purely a version increment to avoid PyPI conflicts
- **Pipeline fixes included**: All the setup.py and workflow fixes from PR #236 are already in main

## Why 0.5.3?

- Version 0.5.2 already exists on PyPI and cannot be overwritten
- Our changes are pipeline fixes, not functional API client changes
- Version 0.5.3 ensures clean release to both PyPI and GHCR
- Follows semantic versioning (patch release for pipeline fixes)

## Release Process

Once this PR is merged:
1. **Automatic PyPI release** will be triggered with version 0.5.3
2. **Automatic GHCR release** will build and push container images
3. **Both platforms** will have the updated package with fixed release pipeline

## Verification

- ✅ **Setup.py structure**: Fixed in previous PR, now working correctly
- ✅ **Version detection**: `python -c "import setup; print(setup.setup_kwargs['version'])"` returns "0.5.3"
- ✅ **Workflow fixes**: ci-status-tracker.yml structure corrected
- ✅ **Tests passing**: All CI/CD checks pass

## Impact

- **Enables**: Clean release to both PyPI and GHCR
- **Resolves**: Version conflict that prevented PyPI publishing
- **Maintains**: All existing functionality and improvements
- **Provides**: Updated containers with fixed release pipeline

This completes the release pipeline fix implementation started in PR #236.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author